### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Potential fix for [https://github.com/glebremniov/budget-buddy-api/security/code-scanning/3](https://github.com/glebremniov/budget-buddy-api/security/code-scanning/3)

In general, the fix is to explicitly declare minimal `GITHUB_TOKEN` permissions for the workflow/job instead of relying on repository defaults. Since `build-and-test` only needs to read the code, `contents: read` is sufficient and aligns with the CodeQL suggestion.

The minimal, non‑breaking change is to add a `permissions` block to the `build-and-test` job directly under `runs-on: ubuntu-latest`. This constrains the token for that job to read‑only repository contents and leaves the existing `docker` job’s `packages: write` permissions untouched. No imports or additional methods are needed; this is purely a YAML configuration change in `.github/workflows/release.yaml` around the `build-and-test` job header.

Concretely, in `.github/workflows/release.yaml`, edit the `build-and-test` job so that:

```yaml
build-and-test:
  runs-on: ubuntu-latest
```

becomes:

```yaml
build-and-test:
  runs-on: ubuntu-latest
  permissions:
    contents: read
```

All other lines remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
