### PR TITLE
Remove unsupported TRANSFER type and de-duplicate sort SQL

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.1.8
+version=0.1.9
 org.gradle.parallel=true
 org.gradle.tooling.parallel=true
 org.gradle.caching=true

--- a/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionRepository.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionRepository.java
@@ -16,27 +16,19 @@ import org.springframework.data.repository.query.Param;
  */
 public interface TransactionRepository extends OwnableEntityRepository<TransactionEntity, UUID> {
 
-  String FIND_ALL_BY_FILTERS_ORDER_BY_DATE_DESC_QUERY = """
+  String FIND_ALL_BY_FILTERS_WHERE_CLAUSE = """
       SELECT * FROM transactions
       WHERE owner_id = :ownerId::uuid
       AND (:startDate::date IS NULL OR date >= :startDate::date)
       AND (:endDate::date IS NULL OR date <= :endDate::date)
       AND (:categoryId::uuid IS NULL OR category_id = :categoryId::uuid)
-      ORDER BY date DESC
-      LIMIT :limit
-      OFFSET :offset
       """;
 
-  String FIND_ALL_BY_FILTERS_ORDER_BY_DATE_ASC_QUERY = """
-      SELECT * FROM transactions
-      WHERE owner_id = :ownerId::uuid
-      AND (:startDate::date IS NULL OR date >= :startDate::date)
-      AND (:endDate::date IS NULL OR date <= :endDate::date)
-      AND (:categoryId::uuid IS NULL OR category_id = :categoryId::uuid)
-      ORDER BY date ASC
-      LIMIT :limit
-      OFFSET :offset
-      """;
+  String FIND_ALL_BY_FILTERS_ORDER_BY_DATE_DESC_QUERY =
+      FIND_ALL_BY_FILTERS_WHERE_CLAUSE + "ORDER BY date DESC LIMIT :limit OFFSET :offset";
+
+  String FIND_ALL_BY_FILTERS_ORDER_BY_DATE_ASC_QUERY =
+      FIND_ALL_BY_FILTERS_WHERE_CLAUSE + "ORDER BY date ASC LIMIT :limit OFFSET :offset";
 
   String COUNT_BY_FILTERS_QUERY = """
       SELECT COUNT(*) FROM transactions

--- a/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionType.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionType.java
@@ -1,5 +1,5 @@
 package com.budget.buddy.budget_buddy_api.transaction;
 
 public enum TransactionType {
-  EXPENSE, INCOME, TRANSFER
+  EXPENSE, INCOME
 }

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -554,7 +554,6 @@ components:
           enum:
             - EXPENSE
             - INCOME
-            - TRANSFER
         currency:
           type: string
           minLength: 3
@@ -587,7 +586,7 @@ components:
           example: 1299
         type:
           type: string
-          enum: [ EXPENSE, INCOME, TRANSFER ]
+          enum: [ EXPENSE, INCOME ]
         currency:
           type: string
           minLength: 3
@@ -610,7 +609,7 @@ components:
           type: integer
         type:
           type: string
-          enum: [ EXPENSE, INCOME, TRANSFER ]
+          enum: [ EXPENSE, INCOME ]
         currency:
           type: string
           minLength: 3


### PR DESCRIPTION
## Summary

- **Remove `TRANSFER` transaction type** — the enum value existed in the spec and entity but had no model support (`toAccountId` / second `categoryId` absent from DB schema and entity). Removed from all three OpenAPI schemas (`Transaction`, `TransactionWrite`, `TransactionUpdate`) and `TransactionType.java`. `POST /v1/transactions` with `type: TRANSFER` now correctly returns 400.
- **De-duplicate sort query constants** — `TransactionRepository` had two near-identical SQL strings differing only in `ORDER BY date ASC/DESC`. Extracted the shared SELECT/WHERE into `FIND_ALL_BY_FILTERS_WHERE_CLAUSE` and derived both query constants via `+` concatenation (required to keep them as compile-time constants for `@Query`). The two `@Query`-annotated methods and `default` router are unchanged.
- Bump version `0.1.8 → 0.1.9`

## Test plan

- [x] `./gradlew openApiGenerate && ./gradlew build` passes
- [x] `./gradlew integrationTest` passes
- [x] `POST /v1/transactions` with `"type": "TRANSFER"` returns HTTP 400
- [x] Transaction list with `sort=asc` and `sort=desc` both return correctly ordered results

🤖 Generated with [Claude Code](https://claude.com/claude-code)