### PR TITLE
chore: improve CI/CD pipeline efficiency and correctness

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -279,17 +279,20 @@ transaction/           # Transaction CRUDL (extends OwnableEntityService)
 All workflows are in `.github/workflows/`:
 
 **`ci.yaml`** — Runs on every push to `main` and pull request:
-- Sets up JDK 25 and Gradle build cache
-- Runs `./gradlew build sonar` (unit tests, integration tests via Testcontainers, SonarQube analysis)
-- Caches SonarQube packages and Gradle dependencies
+- Sets up JDK 25 and Gradle build cache (via `gradle/actions/setup-gradle`)
+- Runs `./gradlew build sonar` (unit tests + SonarQube analysis)
+- Caches SonarQube packages
 - Uploads JAR artifact to GitHub (1-day retention)
 - **Triggers on:** Code changes (`src/`, `build.gradle*`, `gradle/`, `docker-compose*.yaml`)
 - **Requires:** `SONAR_TOKEN` secret, `GITHUB_TOKEN` (auto-provided)
 
-**`release.yaml`** — Triggered manually from Actions tab:
-- Builds and publishes Docker image to GitHub Container Registry (GHCR)
-- Creates GitHub release with changelog
-- Requires `GITHUB_TOKEN` (auto-provided)
+**`release.yaml`** — Triggered automatically when CI passes on `main` (`workflow_run`):
+- `setup` job: reads version from `gradle.properties`, checks if the tag already exists
+- `docker-build` job: builds arm64 and amd64 Docker images in parallel (matrix, `fail-fast: false`), pushes each to GHCR
+- `docker-manifest` job: assembles and pushes a multi-arch manifest + `latest` tag via `docker buildx imagetools`
+- `release` job: creates a git tag and GitHub release with auto-generated notes
+- All jobs after `setup` are skipped if the tag already exists (idempotent)
+- **Requires:** `GITHUB_TOKEN` (auto-provided)
 
 **`dependency-submission.yaml`** — Automatically generates dependency graph for GitHub's supply chain security features
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,13 +55,6 @@ jobs:
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
 
-      - name: Cache Gradle packages
-        uses: actions/cache@v5
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
-
       - name: Build and test
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,53 +1,17 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'src/**'
-      - 'build.gradle*'
-      - 'settings.gradle*'
-      - 'gradle/**'
-      - 'gradlew'
-      - 'gradlew.bat'
-      - '.github/workflows/**'
-      - 'gradle.properties'
-      - 'docker-compose*.yaml'
+  workflow_run:
+    workflows: ['CI']
+    types: [completed]
+    branches: [main]
 
 jobs:
-  build-and-test:
+  setup:
     runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
     permissions:
       contents: read
-      packages: read
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up JDK 25
-        uses: actions/setup-java@v5
-        with:
-          java-version: '25'
-          distribution: 'temurin'
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
-        with:
-          cache-provider: basic
-
-      - name: Build and test
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew build
-
-  docker:
-    runs-on: ubuntu-latest
-    needs: build-and-test
-    permissions:
-      contents: read
-      packages: write
-    env:
-      IMAGE_NAME: ghcr.io/${{ github.repository }}
     outputs:
       version: ${{ steps.read_version.outputs.version }}
       tag_exists: ${{ steps.check_tag.outputs.exists }}
@@ -55,17 +19,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-
-      - name: Set up JDK 25
-        uses: actions/setup-java@v5
-        with:
-          java-version: '25'
-          distribution: 'temurin'
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
-        with:
-          cache-provider: basic
 
       - name: Read version
         id: read_version
@@ -84,63 +37,84 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
+  docker-build:
+    runs-on: ubuntu-latest
+    needs: setup
+    if: needs.setup.outputs.tag_exists == 'false'
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        platform: [linux/arm64, linux/amd64]
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository }}
+      VERSION: ${{ needs.setup.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
+        with:
+          cache-provider: basic
+
       - name: Set up QEMU
-        if: steps.check_tag.outputs.exists == 'false'
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
 
       - name: Log in to GHCR
-        if: steps.check_tag.outputs.exists == 'false'
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build Docker Image arm64
-        if: steps.check_tag.outputs.exists == 'false'
+      - name: Build and push Docker image
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          ARCH=$(echo "${{ matrix.platform }}" | cut -d'/' -f2)
           ./gradlew bootBuildImage -x test \
-            --imagePlatform=linux/arm64 \
-            --imageName=${{ env.IMAGE_NAME }}:${{ env.VERSION }}-arm64
+            --imagePlatform=${{ matrix.platform }} \
+            --imageName=${{ env.IMAGE_NAME }}:${{ env.VERSION }}-$ARCH
+          docker push ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-$ARCH
 
-      - name: Build Docker Image amd64
-        if: steps.check_tag.outputs.exists == 'false'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          ./gradlew bootBuildImage -x test \
-            --imagePlatform=linux/amd64 \
-            --imageName=${{ env.IMAGE_NAME }}:${{ env.VERSION }}-amd64
-
-      - name: Push Docker Images
-        if: steps.check_tag.outputs.exists == 'false'
-        run: |
-          docker push ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-arm64
-          docker push ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-amd64
+  docker-manifest:
+    runs-on: ubuntu-latest
+    needs: [setup, docker-build]
+    permissions:
+      packages: write
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository }}
+      VERSION: ${{ needs.setup.outputs.version }}
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create and push manifest
-        if: steps.check_tag.outputs.exists == 'false'
         run: |
-          docker manifest create ${{ env.IMAGE_NAME }}:${{ env.VERSION }} \
+          docker buildx imagetools create \
+            --tag ${{ env.IMAGE_NAME }}:${{ env.VERSION }} \
+            --tag ${{ env.IMAGE_NAME }}:latest \
             ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-arm64 \
             ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-amd64
-          docker manifest push ${{ env.IMAGE_NAME }}:${{ env.VERSION }}
-
-          docker manifest create ${{ env.IMAGE_NAME }}:latest \
-            ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-arm64 \
-            ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-amd64
-          docker manifest push ${{ env.IMAGE_NAME }}:latest
 
   release:
     runs-on: ubuntu-latest
-    needs: docker
-    if: needs.docker.outputs.tag_exists == 'false'
+    needs: [setup, docker-manifest]
     permissions:
       contents: write
     env:
-      VERSION: ${{ needs.docker.outputs.version }}
+      VERSION: ${{ needs.setup.outputs.version }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,6 +45,7 @@ jobs:
       contents: read
       packages: write
     strategy:
+      fail-fast: false
       matrix:
         platform: [linux/arm64, linux/amd64]
     env:
@@ -87,6 +88,7 @@ jobs:
   docker-manifest:
     runs-on: ubuntu-latest
     needs: [setup, docker-build]
+    if: needs.setup.outputs.tag_exists == 'false'
     permissions:
       packages: write
     env:
@@ -111,6 +113,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [setup, docker-manifest]
+    if: needs.setup.outputs.tag_exists == 'false'
     permissions:
       contents: write
     env:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.1.15
+version=0.1.16
 org.gradle.parallel=true
 org.gradle.tooling.parallel=true
 org.gradle.caching=true


### PR DESCRIPTION
## Why

Four related CI/CD issues identified in the GitHub Actions workflows:

- Redundant Gradle cache configuration in `ci.yaml` (closes #70)
- Full Gradle build running twice on every push to `main` (closes #71)
- Docker arm64 and amd64 images built sequentially (closes #73)
- Deprecated `docker manifest` used for multi-arch manifest assembly (closes #74)

## What changed

- `.github/workflows/ci.yaml`: removed the manual `Cache Gradle packages` step — `gradle/actions/setup-gradle` with `cache-provider: basic` already handles Gradle caching internally; the extra step caused key conflicts and redundant cache writes
- `.github/workflows/release.yaml`: changed trigger from `push` to `workflow_run` on CI success — release now waits for CI to pass rather than running an independent duplicate build
- `.github/workflows/release.yaml`: replaced the `build-and-test` job (full `./gradlew build`) with a lightweight `setup` job that only reads the version from `gradle.properties` and checks whether the git tag already exists — no Gradle invocation needed since CI already verified the build
- `.github/workflows/release.yaml`: split the monolithic `docker` job into a `docker-build` matrix job (arm64 and amd64 build in parallel) and a separate `docker-manifest` assembly job
- `.github/workflows/release.yaml`: replaced deprecated `docker manifest create` / `docker manifest push` with `docker buildx imagetools create`, which assembles both tags in a single command

## Acceptance criteria

- ✅ #70 — `Cache Gradle packages` step removed; `setup-gradle` is the sole Gradle cache mechanism
- ✅ #71 — `release.yaml` triggers via `workflow_run` on CI success; `build-and-test` job eliminated; `./gradlew build` runs once per push to main
- ✅ #73 — `docker-build` is a matrix job; arm64 and amd64 build concurrently in separate runners
- ✅ #74 — `docker buildx imagetools create` replaces deprecated `docker manifest` commands

## How to verify

1. Merge to `main` and confirm only the CI workflow fires immediately; the Release workflow appears in the Actions tab only after CI completes successfully
2. In the Release run, confirm `setup` has no Gradle steps, `docker-build` shows two parallel matrix jobs (arm64 / amd64), and `docker-manifest` uses `imagetools`
3. Confirm the final multi-arch manifest is pushed to GHCR with both `:VERSION` and `:latest` tags

## Notes

The `workflow_run` `branches` filter matches the branch that triggered CI (i.e., `main`), so the path filters from `ci.yaml` remain the effective gate — Release only runs when CI actually runs and succeeds.