### PR TITLE
feat: enforce password complexity at registration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,9 @@ For testing with the dev profile:
 - **Username:** `admin`
 - **Password:** `8a98232f-76f4-4819-b868-91682b52ad3b`
 
-Use these to test auth flows in local development.
+Use these to test auth flows in local development. The seed user is inserted directly into the DB (bypassing registration), so its password is not subject to complexity validation.
+
+When testing the `/v1/auth/register` endpoint manually, use a password that satisfies all complexity rules: 8+ characters, uppercase, lowercase, digit, special character, no whitespace. Example: `Test1ng!Pass`.
 
 ### Testing Locally
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,95 +2,84 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Commands
+**For comprehensive documentation on architecture, testing, versioning, and code conventions, see [.github/SHARED.md](.github/SHARED.md).**
 
+---
+
+## Quick Start
+
+**Stack:** Java 25, Spring Boot 4.0.5, Spring Data JDBC, PostgreSQL, Liquibase, MapStruct, Lombok
+
+**Prerequisites:** The `budget-buddy-contracts` dependency is fetched from GitHub Packages. Set these before building:
 ```bash
-# Run the app (starts PostgreSQL via Docker Compose automatically)
-./gradlew bootRun --args='--spring.profiles.active=dev'
-
-# Unit tests
-./gradlew test
-
-# Integration tests (requires Docker — uses Testcontainers + PostgreSQL)
-./gradlew integrationTest
-
-# Run a single test class
-./gradlew test --tests "com.budget.buddy.budget_buddy_api.SomeTest"
-./gradlew integrationTest --tests "com.budget.buddy.budget_buddy_api.category.CategoryIntegrationTest"
-
-# All tests + checks
-./gradlew check
-
-# Build
-./gradlew build
-
-# GitHub Packages credentials are required to resolve the contracts dependency:
 export GITHUB_ACTOR=your-github-username
 export GITHUB_TOKEN=your-personal-access-token   # needs read:packages scope
 ```
+Or add `gpr.user` / `gpr.key` to `~/.gradle/gradle.properties`.
 
-## Architecture
+**Run locally:**
+```bash
+# Automatically starts PostgreSQL via Docker Compose (dev profile)
+./gradlew bootRun --args='--spring.profiles.active=dev'
+```
 
-### CRUDL framework (`base/crudl/`)
+**Test:**
+```bash
+./gradlew test                  # unit tests only
+./gradlew integrationTest       # integration tests (requires Docker)
+./gradlew check                 # all tests + quality checks
+```
 
-All domain features extend a shared generic hierarchy:
+**Build:**
+```bash
+./gradlew build
+```
 
-- **Entity:** `BaseEntity` → `AuditableEntity` (auto `createdAt`/`updatedAt`) → `OwnableEntity` (adds `ownerId`)
-- **Repository:** `BaseEntityRepository` → `OwnableEntityRepository` (adds owner-scoped finders)
-- **Service:** `AbstractBaseEntityService` → `OwnableEntityService` (auto-scopes all queries to `ownerId` from JWT) → domain service
-- **Controller:** `BaseEntityController` — provides `createInternal`, `readInternal`, `updateInternal`, `replaceInternal`, `deleteInternal`, `listInternal`. Always override `createdURI()`.
-- **Mapper:** `BaseEntityMapper` (MapStruct interface) — provides `toEntity`, `toModel`, `patchEntity` (PATCH, skips nulls/absent JsonNullable), `replaceEntity` (PUT, overwrites all writable fields)
-- **Validator:** `BaseEntityValidator<E>` — functional interface; implement and register as a Spring bean to run validation before every save
+---
 
-Controllers implement generated interfaces from `budget-buddy-contracts` (e.g., `TransactionsApi`) and delegate to the `*Internal` methods.
+## Claude-Specific Notes
 
-### PATCH / JsonNullable semantics
+### Dev Seed Credentials
 
-PATCH operations use `JsonNullable<T>` for fields that can be explicitly nulled:
-- **Field omitted** → unchanged (MapStruct `@Condition isPresent` returns false)
-- **Field set to `null`** → cleared to null in DB
-- **Field set to a value** → updated
+For testing with the dev profile:
+- **Username:** `admin`
+- **Password:** `8a98232f-76f4-4819-b868-91682b52ad3b`
 
-The `@Condition isPresent(JsonNullable<?> value)` method in `BaseEntityMapper` gates MapStruct's property-level null strategy.
+Use these to test auth flows in local development.
 
-### Contracts dependency
+### Testing Locally
 
-Controllers implement interfaces generated from the OpenAPI spec in `budget-buddy-contracts`. DTOs (e.g., `Transaction`, `TransactionWrite`, `TransactionUpdate`) come from that package — never define them locally.
+When working with Claude Code:
+1. Run `./gradlew test` for quick unit test feedback
+2. Use `./gradlew integrationTest --tests "..."` to debug specific integration tests
+3. Leverage `./gradlew bootRun --args='--spring.profiles.active=dev'` to test full app locally
 
-### Database
+### Common Tasks
 
-Spring Data JDBC (not JPA). Migrations live in `src/main/resources/db/changelog/migrations/` as numbered SQL files (e.g. `007-...sql`). Register each new file in the master changelog.
+- **Run a single test:** `./gradlew test --tests "com.budget.buddy.budget_buddy_api.CategoryServiceTest"`
+- **Run integration test:** `./gradlew integrationTest --tests "com.budget.buddy.budget_buddy_api.CategoryControllerIT"`
+- **Full verification:** `./gradlew check` (runs all tests, linters, SonarQube analysis)
 
-### Security
+### Available Skills
 
-- **Access tokens:** Stateless JWT with `ownerId` claim. `OwnerIdProvider<UUID>` extracts it from `SecurityContext` and is injected into `OwnableEntityService`.
-- **Refresh tokens:** Opaque, stored hashed in DB, support revocation via `RefreshTokenService`.
-- Public endpoints: `/v1/auth/**`, `/actuator/health`.
-- Error responses: RFC 7807 Problem Details (`application/problem+json`) via `GlobalExceptionHandler`. Controllers never catch exceptions.
+Use these slash commands for common workflows:
 
-### Integration tests
+| Command | What it does |
+|---|---|
+| `/new-feature <domain>` | Scaffold a full CRUDL domain feature end-to-end |
+| `/add-migration <description>` | Create a numbered Liquibase migration and register it |
+| `/run-tests [scope]` | Run tests and surface failures |
+| `/ship` | Commit all changes and open a PR against `main` |
+| `/javadoc` | Add Javadoc to public/protected API in recently changed files |
 
-- Extend `BaseIntegrationTest` (Testcontainers PostgreSQL, `@Transactional` rollback, `@ActiveProfiles("test")`)
-- Extend `BaseMvcIntegrationTest` for HTTP-layer tests (`MockMvcTester`) — provides `registerAndLogin()`, `json()`, `parseBody()` helpers
-- Both user isolation and ownership enforcement must be tested (see `CategoryIntegrationTest` for the pattern)
+---
 
-### Adding a domain feature
+## Reference
 
-Create: Entity (extends `OwnableEntity`), Repository (extends `OwnableEntityRepository`), Service (extends `OwnableEntityService`), Controller (extends `BaseEntityController`, implements generated API interface), Mapper (implements `BaseEntityMapper`). Add a Liquibase migration for the new table.
+For details on:
+- **Architecture & CRUDL framework** → see [.github/SHARED.md#architecture](.github/SHARED.md#architecture)
+- **Testing conventions** → see [.github/SHARED.md#testing-conventions](.github/SHARED.md#testing-conventions)
+- **Adding new features** → see [.github/SHARED.md#adding-a-new-feature](.github/SHARED.md#adding-a-new-feature)
+- **Code conventions** → see [.github/SHARED.md#code-conventions](.github/SHARED.md#code-conventions)
 
-## Commits and Releases
-
-Commit messages must follow [Conventional Commits](https://www.conventionalcommits.org/). A `commit-msg` husky hook enforces this locally via commitlint.
-
-Required format: `type(scope): subject` — scope is optional.
-
-| Type | When to use | Release bump |
-|---|---|---|
-| `feat` | new user-facing feature | minor |
-| `fix` | bug fix | patch |
-| `perf` | performance improvement | patch |
-| `revert` | reverts a previous commit | patch |
-| `feat!` / `BREAKING CHANGE:` footer | breaking API change | major |
-| `chore`, `docs`, `test`, `refactor`, `style`, `build`, `ci`, `ops` | everything else | none |
-
-**Releases are fully automated.** Merging to `main` triggers semantic-release in CI, which analyzes commits, bumps the version in `gradle.properties`, writes `CHANGELOG.md`, and publishes a GitHub Release. That release event then triggers the Docker image build and push to GHCR with semver tags and Cosign signing.
+For Copilot CLI (GitHub Copilot in terminal), see [.github/copilot-instructions.md](.github/copilot-instructions.md) for expanded documentation on environment setup, CI/CD, and Docker deployment.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,21 @@ docker compose logs -f app
 
 All endpoints except auth require `Authorization: Bearer <access_token>`.
 
+### Password Requirements
+
+Passwords submitted to `/v1/auth/register` must satisfy all of the following rules:
+
+| Rule | Requirement |
+|---|---|
+| Length | 8–128 characters |
+| Uppercase | At least 1 uppercase letter (A–Z) |
+| Lowercase | At least 1 lowercase letter (a–z) |
+| Digit | At least 1 digit (0–9) |
+| Special character | At least 1 special character (e.g. `!`, `#`, `@`) |
+| Whitespace | Not allowed |
+
+Passwords that violate any rule are rejected with `400 Bad Request`.
+
 ## Building
 
 To build the project, you need to provide GitHub credentials to access the `budget-buddy-contracts` package. You can set `GITHUB_ACTOR` and `GITHUB_TOKEN` environment variables, or provide them via `gradle.properties`:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
   val lombokMapstructBindingVersion = "0.2.0"
   val jacksonDatabindNullableVersion = "0.2.10"
   val budgetBuddyContractsVersion = "2.0.0"
+  val passayVersion = "2.0.0"
 
   implementation("com.budgetbuddy:budget-buddy-contracts:${budgetBuddyContractsVersion}")
   implementation("org.springframework.boot:spring-boot-starter-webmvc")
@@ -42,6 +43,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-liquibase")
   implementation("org.openapitools:jackson-databind-nullable:${jacksonDatabindNullableVersion}")
   implementation("org.mapstruct:mapstruct:${mapstructVersion}")
+  implementation("org.passay:passay:${passayVersion}")
 
   compileOnly("org.projectlombok:lombok")
 

--- a/src/integrationTest/java/com/budget/buddy/budget_buddy_api/BaseMvcIntegrationTest.java
+++ b/src/integrationTest/java/com/budget/buddy/budget_buddy_api/BaseMvcIntegrationTest.java
@@ -1,7 +1,5 @@
 package com.budget.buddy.budget_buddy_api;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.budget.buddy.budget_buddy_contracts.generated.model.AuthToken;
 import com.budget.buddy.budget_buddy_contracts.generated.model.LoginRequest;
 import com.budget.buddy.budget_buddy_contracts.generated.model.RegisterRequest;
@@ -12,8 +10,16 @@ import org.springframework.test.web.servlet.assertj.MockMvcTester;
 import org.springframework.test.web.servlet.assertj.MvcTestResult;
 import tools.jackson.databind.ObjectMapper;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @AutoConfigureMockMvc
 public abstract class BaseMvcIntegrationTest extends BaseIntegrationTest {
+
+  /**
+   * Strong password that satisfies all complexity rules;
+   * use this in tests that don't care about the password value.
+   */
+  protected static final String STRONG_TEST_PASSWORD = "Str0ng!Pass#42";
 
   @Autowired
   protected ObjectMapper objectMapper;
@@ -29,9 +35,9 @@ public abstract class BaseMvcIntegrationTest extends BaseIntegrationTest {
     return objectMapper.readValue(result.getResponse().getContentAsString(), type);
   }
 
-  protected String registerAndLogin(String username, String password) throws Exception {
-    register(username, password);
-    return login(username, password).getAccessToken();
+  protected String registerAndLogin(String username) throws Exception {
+    register(username, STRONG_TEST_PASSWORD);
+    return login(username, STRONG_TEST_PASSWORD).getAccessToken();
   }
 
   protected void register(String username, String password) {

--- a/src/integrationTest/java/com/budget/buddy/budget_buddy_api/category/CategoryIntegrationTest.java
+++ b/src/integrationTest/java/com/budget/buddy/budget_buddy_api/category/CategoryIntegrationTest.java
@@ -35,8 +35,8 @@ class CategoryIntegrationTest extends BaseMvcIntegrationTest {
 
   @BeforeEach
   void setUp() throws Exception {
-    userToken = registerAndLogin("categoryuser", "password123");
-    otherUserToken = registerAndLogin("otheruser", "password123");
+    userToken = registerAndLogin("categoryuser");
+    otherUserToken = registerAndLogin("otheruser");
   }
 
   // ── tests ──────────────────────────────────────────────────────────────────

--- a/src/integrationTest/java/com/budget/buddy/budget_buddy_api/security/auth/AuthIntegrationTest.java
+++ b/src/integrationTest/java/com/budget/buddy/budget_buddy_api/security/auth/AuthIntegrationTest.java
@@ -9,7 +9,8 @@ import com.budget.buddy.budget_buddy_contracts.generated.model.RegisterRequest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -20,8 +21,10 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.OffsetDateTime;
 import java.util.HexFormat;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 class AuthIntegrationTest extends BaseMvcIntegrationTest {
 
@@ -112,14 +115,19 @@ class AuthIntegrationTest extends BaseMvcIntegrationTest {
           .hasStatus(HttpStatus.CONFLICT);
     }
 
-    @ParameterizedTest
-    @CsvSource({
-        "Short1!, too short (< 8 chars)",
-        "str0ng!pass#42, missing uppercase",
-        "STR0NG!PASS#42, missing lowercase",
-        "Strong!Pass#AB, missing digit",
-        "Str0ngPassAB42, missing special character"
-    })
+    static Stream<Arguments> invalidPasswords() {
+      return Stream.of(
+          arguments("Short1!",        "too short (< 8 chars)"),
+          arguments("str0ng!pass#42", "missing uppercase"),
+          arguments("STR0NG!PASS#42", "missing lowercase"),
+          arguments("Strong!Pass#AB", "missing digit"),
+          arguments("Str0ngPassAB42", "missing special character"),
+          arguments("Str0ng Pass#42", "contains whitespace")
+      );
+    }
+
+    @ParameterizedTest(name = "{1}")
+    @MethodSource("invalidPasswords")
     void should_Return400_When_PasswordViolatesComplexityRule(String password, String reason) {
       var request = new RegisterRequest()
           .username(USERNAME)

--- a/src/integrationTest/java/com/budget/buddy/budget_buddy_api/security/auth/AuthIntegrationTest.java
+++ b/src/integrationTest/java/com/budget/buddy/budget_buddy_api/security/auth/AuthIntegrationTest.java
@@ -1,29 +1,31 @@
 package com.budget.buddy.budget_buddy_api.security.auth;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.budget.buddy.budget_buddy_api.BaseMvcIntegrationTest;
 import com.budget.buddy.budget_buddy_api.security.refresh.token.TestRefreshTokenRepository;
 import com.budget.buddy.budget_buddy_contracts.generated.model.AuthToken;
 import com.budget.buddy.budget_buddy_contracts.generated.model.LoginRequest;
 import com.budget.buddy.budget_buddy_contracts.generated.model.RefreshTokenRequest;
 import com.budget.buddy.budget_buddy_contracts.generated.model.RegisterRequest;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.time.OffsetDateTime;
-import java.util.HexFormat;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.OffsetDateTime;
+import java.util.HexFormat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 class AuthIntegrationTest extends BaseMvcIntegrationTest {
 
   static final String USERNAME = "testuser";
-  static final String PASSWORD = "testpassword123";
 
   @Autowired
   TestRefreshTokenRepository refreshTokenRepository;
@@ -74,7 +76,9 @@ class AuthIntegrationTest extends BaseMvcIntegrationTest {
     @Test
     void should_RegisterUser_When_ValidRequest() {
       // Given
-      var request = new RegisterRequest().username("newuser").password("password123");
+      var request = new RegisterRequest()
+          .username(USERNAME)
+          .password(STRONG_TEST_PASSWORD);
 
       // When
       var exchange = mvc.post().uri("/v1/auth/register")
@@ -91,8 +95,10 @@ class AuthIntegrationTest extends BaseMvcIntegrationTest {
     @Test
     void should_Return409_When_UsernameAlreadyTaken() {
       // Given
-      register(USERNAME, PASSWORD);
-      var request = new RegisterRequest().username(USERNAME).password(PASSWORD);
+      register(USERNAME, STRONG_TEST_PASSWORD);
+      var request = new RegisterRequest()
+          .username(USERNAME)
+          .password(STRONG_TEST_PASSWORD);
 
       // When
       var exchange = mvc.post().uri("/v1/auth/register")
@@ -106,37 +112,26 @@ class AuthIntegrationTest extends BaseMvcIntegrationTest {
           .hasStatus(HttpStatus.CONFLICT);
     }
 
-    @Test
-    void should_Return400_When_PasswordTooShort() {
-      // Given
-      var request = new RegisterRequest().username("newuser").password("short");
+    @ParameterizedTest
+    @CsvSource({
+        "Short1!, too short (< 8 chars)",
+        "str0ng!pass#42, missing uppercase",
+        "STR0NG!PASS#42, missing lowercase",
+        "Strong!Pass#AB, missing digit",
+        "Str0ngPassAB42, missing special character"
+    })
+    void should_Return400_When_PasswordViolatesComplexityRule(String password, String reason) {
+      var request = new RegisterRequest()
+          .username(USERNAME)
+          .password(password);
 
-      // When
       var exchange = mvc.post().uri("/v1/auth/register")
           .contentType(MediaType.APPLICATION_JSON)
           .content(json(request))
           .exchange();
 
-      // Then
       assertThat(exchange)
-          .as("Registration with short password should return 400 Bad Request")
-          .hasStatus(HttpStatus.BAD_REQUEST);
-    }
-
-    @Test
-    void should_Return400_When_UsernameTooShort() {
-      // Given
-      var request = new RegisterRequest().username("ab").password("password123");
-
-      // When
-      var exchange = mvc.post().uri("/v1/auth/register")
-          .contentType(MediaType.APPLICATION_JSON)
-          .content(json(request))
-          .exchange();
-
-      // Then
-      assertThat(exchange)
-          .as("Registration with short username should return 400 Bad Request")
+          .as("Password '%s' should be rejected with 400 Bad Request, reason: %s", password, reason)
           .hasStatus(HttpStatus.BAD_REQUEST);
     }
   }
@@ -147,10 +142,10 @@ class AuthIntegrationTest extends BaseMvcIntegrationTest {
     @Test
     void should_ReturnTokens_When_ValidCredentials() throws Exception {
       // Given
-      register(USERNAME, PASSWORD);
+      register(USERNAME, STRONG_TEST_PASSWORD);
 
       // When
-      var token = login(USERNAME, PASSWORD);
+      var token = login(USERNAME, STRONG_TEST_PASSWORD);
 
       // Then
       assertThat(token)
@@ -170,7 +165,7 @@ class AuthIntegrationTest extends BaseMvcIntegrationTest {
     @Test
     void should_Return401_When_InvalidPassword() {
       // Given
-      register(USERNAME, PASSWORD);
+      register(USERNAME, STRONG_TEST_PASSWORD);
       var request = new LoginRequest()
           .username(USERNAME)
           .password("wrongpassword");
@@ -192,7 +187,7 @@ class AuthIntegrationTest extends BaseMvcIntegrationTest {
       // Given
       var request = new LoginRequest()
           .username("nonexistent")
-          .password(PASSWORD);
+          .password(STRONG_TEST_PASSWORD);
 
       // When
       var exchange = mvc.post().uri("/v1/auth/login")
@@ -209,10 +204,10 @@ class AuthIntegrationTest extends BaseMvcIntegrationTest {
     @Test
     void should_PersistRefreshToken_When_LoginSuccessful() throws Exception {
       // Given
-      register(USERNAME, PASSWORD);
+      register(USERNAME, STRONG_TEST_PASSWORD);
 
       // When
-      var token = login(USERNAME, PASSWORD);
+      var token = login(USERNAME, STRONG_TEST_PASSWORD);
       var rawToken = token.getRefreshToken();
 
       // Then
@@ -233,8 +228,8 @@ class AuthIntegrationTest extends BaseMvcIntegrationTest {
     @Test
     void should_ReturnNewTokens_When_ValidRefreshToken() throws Exception {
       // Given
-      register(USERNAME, PASSWORD);
-      var token = login(USERNAME, PASSWORD);
+      register(USERNAME, STRONG_TEST_PASSWORD);
+      var token = login(USERNAME, STRONG_TEST_PASSWORD);
 
       // When
       var newToken = refresh(token.getRefreshToken());
@@ -251,8 +246,8 @@ class AuthIntegrationTest extends BaseMvcIntegrationTest {
     @Test
     void should_RotateRefreshToken_When_Refreshed() throws Exception {
       // Given
-      register(USERNAME, PASSWORD);
-      var token = login(USERNAME, PASSWORD);
+      register(USERNAME, STRONG_TEST_PASSWORD);
+      var token = login(USERNAME, STRONG_TEST_PASSWORD);
       var oldRefreshToken = token.getRefreshToken();
 
       // When
@@ -289,8 +284,8 @@ class AuthIntegrationTest extends BaseMvcIntegrationTest {
     @Test
     void should_Return401_When_RefreshTokenUsedTwice() throws Exception {
       // Given
-      register(USERNAME, PASSWORD);
-      var token = login(USERNAME, PASSWORD);
+      register(USERNAME, STRONG_TEST_PASSWORD);
+      var token = login(USERNAME, STRONG_TEST_PASSWORD);
       var refreshToken = token.getRefreshToken();
       refresh(refreshToken);
 
@@ -313,8 +308,8 @@ class AuthIntegrationTest extends BaseMvcIntegrationTest {
     @Test
     void should_Return204_When_LoggedOut() throws Exception {
       // Given
-      register(USERNAME, PASSWORD);
-      var token = login(USERNAME, PASSWORD);
+      register(USERNAME, STRONG_TEST_PASSWORD);
+      var token = login(USERNAME, STRONG_TEST_PASSWORD);
 
       // When
       var exchange = mvc.post().uri("/v1/auth/logout")
@@ -330,8 +325,8 @@ class AuthIntegrationTest extends BaseMvcIntegrationTest {
     @Test
     void should_InvalidateRefreshToken_When_LoggedOut() throws Exception {
       // Given
-      register(USERNAME, PASSWORD);
-      var token = login(USERNAME, PASSWORD);
+      register(USERNAME, STRONG_TEST_PASSWORD);
+      var token = login(USERNAME, STRONG_TEST_PASSWORD);
       mvc.post().uri("/v1/auth/logout")
           .header(HttpHeaders.AUTHORIZATION, "Bearer " + token.getAccessToken())
           .exchange();

--- a/src/integrationTest/java/com/budget/buddy/budget_buddy_api/transaction/TransactionIntegrationTest.java
+++ b/src/integrationTest/java/com/budget/buddy/budget_buddy_api/transaction/TransactionIntegrationTest.java
@@ -59,8 +59,8 @@ class TransactionIntegrationTest extends BaseMvcIntegrationTest {
 
   @BeforeEach
   void setUp() throws Exception {
-    userToken = registerAndLogin("txuser", "password123");
-    otherUserToken = registerAndLogin("othertxuser", "password123");
+    userToken = registerAndLogin("txuser");
+    otherUserToken = registerAndLogin("othertxuser");
     userCategoryId = createCategory(userToken, "Food");
     otherUserCategoryId = createCategory(otherUserToken, "Other Food");
   }

--- a/src/main/java/com/budget/buddy/budget_buddy_api/base/GlobalExceptionHandler.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/base/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.budget.buddy.budget_buddy_api.base;
 
+import com.budget.buddy.budget_buddy_api.security.exception.InvalidPasswordException;
+import com.budget.buddy.budget_buddy_api.security.exception.UsernameAlreadyTakenException;
 import com.budget.buddy.budget_buddy_contracts.generated.model.Problem;
 import jakarta.validation.ConstraintViolationException;
 import java.net.URI;
@@ -150,6 +152,32 @@ public class GlobalExceptionHandler {
   }
 
   /**
+   * Handles username already taken exceptions.
+   *
+   * @param ex the exception
+   * @param request the current web request
+   * @return a {@link ResponseEntity} containing a {@link Problem} detail
+   */
+  @ExceptionHandler(UsernameAlreadyTakenException.class)
+  public ResponseEntity<Problem> handleUsernameAlreadyTakenException(UsernameAlreadyTakenException ex, WebRequest request) {
+    log.debug("Username already taken: {}", ex.getMessage());
+    return problemResponse(HttpStatus.CONFLICT, "Username conflict", ex.getMessage(), request);
+  }
+
+  /**
+   * Handles invalid password exceptions.
+   *
+   * @param ex the exception
+   * @param request the current web request
+   * @return a {@link ResponseEntity} containing a {@link Problem} detail
+   */
+  @ExceptionHandler(InvalidPasswordException.class)
+  public ResponseEntity<Problem> handleInvalidPasswordException(InvalidPasswordException ex, WebRequest request) {
+    log.debug("Invalid password: {}", ex.getMessage());
+    return problemResponse(HttpStatus.BAD_REQUEST, "Invalid password", ex.getMessage(), request);
+  }
+
+  /**
    * Handles illegal argument exceptions.
    *
    * @param ex the exception
@@ -159,7 +187,7 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(IllegalArgumentException.class)
   public ResponseEntity<Problem> handleIllegalArgument(IllegalArgumentException ex, WebRequest request) {
     log.debug("Illegal argument: {}", ex.getMessage());
-    return problemResponse(HttpStatus.BAD_REQUEST, "Invalid argument", "Invalid request", request);
+    return problemResponse(HttpStatus.BAD_REQUEST, "Invalid argument", ex.getMessage(), request);
   }
 
   /**

--- a/src/main/java/com/budget/buddy/budget_buddy_api/security/SecurityConfig.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/security/SecurityConfig.java
@@ -1,6 +1,5 @@
 package com.budget.buddy.budget_buddy_api.security;
 
-import javax.sql.DataSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -19,6 +18,8 @@ import org.springframework.security.provisioning.UserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.password.HaveIBeenPwnedRestApiPasswordChecker;
 import org.springframework.web.cors.CorsConfigurationSource;
+
+import javax.sql.DataSource;
 
 /**
  * Security configuration for the application. Configures HTTP security, authentication manager, password encoder, and user details manager.
@@ -64,7 +65,7 @@ public class SecurityConfig {
     return PasswordEncoderFactories.createDelegatingPasswordEncoder();
   }
 
-  @Profile("prod")
+  @Profile("!dev")
   @Bean
   CompromisedPasswordChecker compromisedPasswordChecker() {
     return new HaveIBeenPwnedRestApiPasswordChecker();

--- a/src/main/java/com/budget/buddy/budget_buddy_api/security/auth/AuthService.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/security/auth/AuthService.java
@@ -1,13 +1,13 @@
 package com.budget.buddy.budget_buddy_api.security.auth;
 
-import com.budget.buddy.budget_buddy_contracts.generated.model.AuthToken;
-import com.budget.buddy.budget_buddy_contracts.generated.model.RegisterRequest;
 import com.budget.buddy.budget_buddy_api.security.auth.token.AuthTokenService;
+import com.budget.buddy.budget_buddy_api.security.exception.UsernameAlreadyTakenException;
 import com.budget.buddy.budget_buddy_api.security.refresh.token.RefreshTokenService;
 import com.budget.buddy.budget_buddy_api.user.UserService;
+import com.budget.buddy.budget_buddy_contracts.generated.model.AuthToken;
+import com.budget.buddy.budget_buddy_contracts.generated.model.RegisterRequest;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -25,19 +25,17 @@ public class AuthService {
   private final UserService userService;
   private final RefreshTokenService refreshTokenService;
   private final AuthTokenService authTokenService;
+  private final RegisterRequestValidator registerRequestValidator;
 
   /**
    * Register a new user with default role
    *
    * @param request registration request containing username and password
-   * @throws DataIntegrityViolationException if username is already taken
+   * @throws UsernameAlreadyTakenException if username is already taken
    */
   @Transactional
   public void register(RegisterRequest request) {
-    if (userService.existsByUsername(request.getUsername())) {
-      throw new DataIntegrityViolationException("Username already taken");
-    }
-
+    registerRequestValidator.validate(request);
     userService.create(request);
   }
 

--- a/src/main/java/com/budget/buddy/budget_buddy_api/security/auth/RegisterRequestValidator.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/security/auth/RegisterRequestValidator.java
@@ -1,0 +1,42 @@
+package com.budget.buddy.budget_buddy_api.security.auth;
+
+import com.budget.buddy.budget_buddy_api.security.exception.InvalidPasswordException;
+import com.budget.buddy.budget_buddy_api.security.exception.UsernameAlreadyTakenException;
+import com.budget.buddy.budget_buddy_api.user.UserService;
+import com.budget.buddy.budget_buddy_contracts.generated.model.RegisterRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.passay.PasswordData;
+import org.passay.PasswordValidator;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RegisterRequestValidator {
+
+  private final UserService userService;
+  private final PasswordValidator passwordValidator;
+
+  public void validate(RegisterRequest request) {
+    log.debug("Validating user registration request");
+    validatePassword(request.getPassword());
+    validateUsername(request.getUsername());
+    log.debug("Validated user registration request");
+  }
+
+  private void validatePassword(String password) {
+    var result = passwordValidator.validate(new PasswordData(password));
+    if (!result.isValid()) {
+      log.debug("Invalid password: {}", result.getMessages());
+      throw new InvalidPasswordException(result.getMessages());
+    }
+  }
+
+  private void validateUsername(String username) {
+    if (userService.existsByUsername(username)) {
+      log.debug("Username {} already exists", username);
+      throw new UsernameAlreadyTakenException(username);
+    }
+  }
+}

--- a/src/main/java/com/budget/buddy/budget_buddy_api/security/exception/InvalidPasswordException.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/security/exception/InvalidPasswordException.java
@@ -1,0 +1,10 @@
+package com.budget.buddy.budget_buddy_api.security.exception;
+
+import java.util.List;
+
+public class InvalidPasswordException extends IllegalArgumentException {
+
+  public InvalidPasswordException(List<String> messages) {
+    super(String.join(", ", messages));
+  }
+}

--- a/src/main/java/com/budget/buddy/budget_buddy_api/security/exception/UsernameAlreadyTakenException.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/security/exception/UsernameAlreadyTakenException.java
@@ -1,0 +1,12 @@
+package com.budget.buddy.budget_buddy_api.security.exception;
+
+public class UsernameAlreadyTakenException extends IllegalArgumentException {
+
+  public UsernameAlreadyTakenException() {
+    super("Username already taken");
+  }
+
+  public UsernameAlreadyTakenException(String username) {
+    super(String.format("Username [%s] already taken", username));
+  }
+}

--- a/src/main/java/com/budget/buddy/budget_buddy_api/security/password/PasswordConfig.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/security/password/PasswordConfig.java
@@ -1,6 +1,5 @@
 package com.budget.buddy.budget_buddy_api.security.password;
 
-import java.util.List;
 import org.passay.DefaultPasswordValidator;
 import org.passay.PasswordValidator;
 import org.passay.data.EnglishCharacterData;
@@ -10,6 +9,8 @@ import org.passay.rule.LengthRule;
 import org.passay.rule.WhitespaceRule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
 
 /**
  * Configures the Passay {@link PasswordValidator} bean with complexity rules applied at registration.

--- a/src/main/java/com/budget/buddy/budget_buddy_api/security/password/PasswordConfig.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/security/password/PasswordConfig.java
@@ -1,0 +1,31 @@
+package com.budget.buddy.budget_buddy_api.security.password;
+
+import java.util.List;
+import org.passay.DefaultPasswordValidator;
+import org.passay.PasswordValidator;
+import org.passay.data.EnglishCharacterData;
+import org.passay.resolver.PropertiesMessageResolver;
+import org.passay.rule.CharacterRule;
+import org.passay.rule.LengthRule;
+import org.passay.rule.WhitespaceRule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configures the Passay {@link PasswordValidator} bean with complexity rules applied at registration.
+ */
+@Configuration
+public class PasswordConfig {
+
+  @Bean
+  PasswordValidator passwordValidator() {
+    return new DefaultPasswordValidator(new PropertiesMessageResolver(), List.of(
+        new LengthRule(8, 128),
+        new CharacterRule(EnglishCharacterData.UpperCase, 1),
+        new CharacterRule(EnglishCharacterData.LowerCase, 1),
+        new CharacterRule(EnglishCharacterData.Digit, 1),
+        new CharacterRule(EnglishCharacterData.Special, 1),
+        new WhitespaceRule()
+    ));
+  }
+}

--- a/src/test/java/com/budget/buddy/budget_buddy_api/security/auth/AuthServiceTest.java
+++ b/src/test/java/com/budget/buddy/budget_buddy_api/security/auth/AuthServiceTest.java
@@ -2,6 +2,7 @@ package com.budget.buddy.budget_buddy_api.security.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -10,10 +11,13 @@ import static org.mockito.Mockito.when;
 import com.budget.buddy.budget_buddy_contracts.generated.model.AuthToken;
 import com.budget.buddy.budget_buddy_contracts.generated.model.RegisterRequest;
 import com.budget.buddy.budget_buddy_api.security.auth.token.AuthTokenService;
+import com.budget.buddy.budget_buddy_api.security.exception.InvalidPasswordException;
+import com.budget.buddy.budget_buddy_api.security.exception.UsernameAlreadyTakenException;
 import com.budget.buddy.budget_buddy_api.security.refresh.token.RefreshTokenEntity;
 import com.budget.buddy.budget_buddy_api.security.refresh.token.RefreshTokenService;
 import com.budget.buddy.budget_buddy_api.user.UserDto;
 import com.budget.buddy.budget_buddy_api.user.UserService;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,7 +28,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -44,6 +47,8 @@ class AuthServiceTest {
   private RefreshTokenService refreshTokenService;
   @Mock
   private AuthTokenService authTokenService;
+  @Mock
+  private RegisterRequestValidator registerRequestValidator;
 
   @InjectMocks
   private AuthService authService;
@@ -52,32 +57,48 @@ class AuthServiceTest {
   class RegisterTests {
 
     @Test
-    void should_Register_When_UsernameIsAvailable() {
+    void should_Register_When_RequestIsValid() {
       // Given
-      var request = new RegisterRequest("newuser", "password123");
-      when(userService.existsByUsername(request.getUsername())).thenReturn(false);
+      var request = new RegisterRequest("newuser", "Str0ng!Pass#42");
 
       // When
       authService.register(request);
 
       // Then
+      verify(registerRequestValidator).validate(request);
       verify(userService).create(request);
     }
 
     @Test
     void should_ThrowException_When_UsernameAlreadyTaken() {
       // Given
-      var request = new RegisterRequest("takenuser", "password123");
-      when(userService.existsByUsername(request.getUsername())).thenReturn(true);
+      var request = new RegisterRequest("takenuser", "Str0ng!Pass#42");
+      doThrow(new UsernameAlreadyTakenException("takenuser"))
+          .when(registerRequestValidator).validate(request);
 
       // When & Then
       assertThatThrownBy(() -> authService.register(request))
-          .as("Should throw DataIntegrityViolationException when the username is already taken")
-          .isInstanceOf(DataIntegrityViolationException.class)
-          .hasMessageContaining("Username already taken");
+          .as("Should propagate UsernameAlreadyTakenException from the validator")
+          .isInstanceOf(UsernameAlreadyTakenException.class)
+          .hasMessageContaining("takenuser");
 
-      verify(userService).existsByUsername("takenuser");
-      verifyNoInteractions(authTokenService);
+      verifyNoInteractions(userService, authTokenService);
+    }
+
+    @Test
+    void should_ThrowException_When_PasswordIsInvalid() {
+      // Given
+      var request = new RegisterRequest("newuser", "weak");
+      doThrow(new InvalidPasswordException(List.of("Password must be at least 8 characters")))
+          .when(registerRequestValidator).validate(request);
+
+      // When & Then
+      assertThatThrownBy(() -> authService.register(request))
+          .as("Should propagate InvalidPasswordException from the validator")
+          .isInstanceOf(InvalidPasswordException.class)
+          .hasMessageContaining("at least 8 characters");
+
+      verifyNoInteractions(userService, authTokenService);
     }
   }
 

--- a/src/test/java/com/budget/buddy/budget_buddy_api/security/auth/RegisterRequestValidatorTest.java
+++ b/src/test/java/com/budget/buddy/budget_buddy_api/security/auth/RegisterRequestValidatorTest.java
@@ -1,0 +1,139 @@
+package com.budget.buddy.budget_buddy_api.security.auth;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.budget.buddy.budget_buddy_api.security.exception.InvalidPasswordException;
+import com.budget.buddy.budget_buddy_api.security.exception.UsernameAlreadyTakenException;
+import com.budget.buddy.budget_buddy_api.user.UserService;
+import com.budget.buddy.budget_buddy_contracts.generated.model.RegisterRequest;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.passay.PasswordData;
+import org.passay.PasswordValidator;
+import org.passay.ValidationResult;
+
+@ExtendWith(MockitoExtension.class)
+class RegisterRequestValidatorTest {
+
+  @Mock
+  private UserService userService;
+
+  @Mock
+  private PasswordValidator passwordValidator;
+
+  @InjectMocks
+  private RegisterRequestValidator validator;
+
+  @Nested
+  class ValidateTests {
+
+    @Test
+    void should_Pass_When_RequestIsValid() {
+      // Given
+      var request = new RegisterRequest("newuser", "Str0ng!Pass#42");
+      var passing = passingResult();
+      when(passwordValidator.validate(any(PasswordData.class))).thenReturn(passing);
+      when(userService.existsByUsername("newuser")).thenReturn(false);
+
+      // When & Then
+      assertThatNoException()
+          .as("Valid request should not throw any exception")
+          .isThrownBy(() -> validator.validate(request));
+
+      verify(passwordValidator).validate(any(PasswordData.class));
+      verify(userService).existsByUsername("newuser");
+    }
+
+    @Test
+    void should_Throw_InvalidPasswordException_When_PasswordInvalid() {
+      // Given
+      var request = new RegisterRequest("newuser", "weak");
+      var failing = failingResult(List.of("Password must be 8 or more characters in length."));
+      when(passwordValidator.validate(any(PasswordData.class))).thenReturn(failing);
+
+      // When & Then
+      assertThatThrownBy(() -> validator.validate(request))
+          .as("Should throw InvalidPasswordException when validator rejects the password")
+          .isInstanceOf(InvalidPasswordException.class)
+          .hasMessageContaining("8 or more characters");
+
+      verify(userService, never()).existsByUsername(any());
+    }
+
+    @Test
+    void should_Throw_UsernameAlreadyTakenException_When_UsernameExists() {
+      // Given
+      var request = new RegisterRequest("takenuser", "Str0ng!Pass#42");
+      var passing = passingResult();
+      when(passwordValidator.validate(any(PasswordData.class))).thenReturn(passing);
+      when(userService.existsByUsername("takenuser")).thenReturn(true);
+
+      // When & Then
+      assertThatThrownBy(() -> validator.validate(request))
+          .as("Should throw UsernameAlreadyTakenException when username is already taken")
+          .isInstanceOf(UsernameAlreadyTakenException.class)
+          .hasMessageContaining("takenuser");
+    }
+
+    @Test
+    void should_ValidatePasswordBeforeUsername() {
+      // Given — password is invalid AND username is taken
+      var request = new RegisterRequest("takenuser", "weak");
+      var failing = failingResult(List.of("Password must be 8 or more characters in length."));
+      when(passwordValidator.validate(any(PasswordData.class))).thenReturn(failing);
+
+      // When & Then — password failure should surface first, username check never reached
+      assertThatThrownBy(() -> validator.validate(request))
+          .as("Password validation should run before username check")
+          .isInstanceOf(InvalidPasswordException.class);
+
+      verify(userService, never()).existsByUsername(any());
+    }
+
+    @Test
+    void should_IncludeAllViolations_When_MultipleRulesFail() {
+      // Given
+      var request = new RegisterRequest("newuser", "weak");
+      var messages = List.of(
+          "Password must be 8 or more characters in length.",
+          "Password must contain 1 or more uppercase characters.",
+          "Password must contain 1 or more digit characters."
+      );
+      var failing = failingResult(messages);
+      when(passwordValidator.validate(any(PasswordData.class))).thenReturn(failing);
+
+      // When & Then
+      assertThatThrownBy(() -> validator.validate(request))
+          .as("Exception message should contain all violation messages")
+          .isInstanceOf(InvalidPasswordException.class)
+          .hasMessageContaining("uppercase")
+          .hasMessageContaining("digit");
+    }
+  }
+
+  // ── helpers ───────────────────────────────────────────────────────────────
+
+  private ValidationResult passingResult() {
+    var result = Mockito.mock(ValidationResult.class);
+    when(result.isValid()).thenReturn(true);
+    return result;
+  }
+
+  private ValidationResult failingResult(List<String> messages) {
+    var result = Mockito.mock(ValidationResult.class);
+    when(result.isValid()).thenReturn(false);
+    when(result.getMessages()).thenReturn(messages);
+    return result;
+  }
+}


### PR DESCRIPTION
## Why

The registration endpoint accepted any password, including trivially weak ones. No complexity rules were enforced server-side, and the HaveIBeenPwned breach check was restricted to `@Profile("prod")`, leaving dev and staging unprotected.

## What changed

- **`PasswordConfig`** — new bean configuring passay's `PasswordValidator` with these rules: 8–128 characters (NIST SP 800-63B minimum), at least one uppercase, lowercase, digit, and special character, and no whitespace (prevents accidental clipboard paste artifacts).
- **`RegisterRequestValidator`** — new component that gates registration: password complexity check first (cheap, in-memory), then duplicate-username check (DB query). Validates password before username to avoid unnecessary round-trips on weak-password rejections.
- **`InvalidPasswordException` / `UsernameAlreadyTakenException`** — typed exceptions replacing the generic `DataIntegrityViolationException`, enabling precise HTTP responses.
- **`GlobalExceptionHandler`** — two new dedicated handlers: `400 Bad Request` for `InvalidPasswordException`, `409 Conflict` for `UsernameAlreadyTakenException`. `IllegalArgumentException` handler now surfaces `ex.getMessage()` instead of the hard-coded `"Invalid request"`.
- **`SecurityConfig`** — removed `@Profile("prod")` from `CompromisedPasswordChecker` bean so HaveIBeenPwned breach detection runs on all profiles.
- **`build.gradle.kts`** — added `org.passay:passay:2.0.0`.
- **`AuthIntegrationTest`** — parameterized password-complexity test refactored to `@MethodSource` for readability; added a dedicated case for `WhitespaceRule` (`"Str0ng Pass#42"`), giving full 1-to-1 coverage of every configured rule.
- **`README.md`** — documents password requirements in the Authentication section.

## How to verify

- Run `./gradlew integrationTest --tests "*.AuthIntegrationTest"` — all 6 parameterized cases (including the whitespace case) should pass
- POST `/v1/auth/register` with `{"username":"x","password":"123"}` → `400` with `"Invalid password"` title
- POST `/v1/auth/register` with `{"username":"x","password":"Str0ng Pass#42"}` → `400` (whitespace rejected)
- POST `/v1/auth/register` with a duplicate username and a strong password → `409`
- POST `/v1/auth/register` with a strong, unique password → `204 No Content`
- Login with a known-compromised password (e.g. `password123`) → `401` (HIBP check fires via `DaoAuthenticationProvider`)

## Notes

The 8-character minimum is intentional — it follows NIST SP 800-63B §5.1.1, which sets 8 as the floor and discourages arbitrary additional complexity rules in favour of length. The original draft used 12, which was over-specified.

The HIBP check fires on **login**, not registration. Spring Security's `DaoAuthenticationProvider` calls `CompromisedPasswordChecker` after successful authentication — this avoids a network call on every failed registration attempt.