### PR TITLE
Align API with contracts v1.4.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
   val mapstructVersion = "1.6.3"
   val lombokMapstructBindingVersion = "0.2.0"
   val jacksonDatabindNullableVersion = "0.2.10"
-  val budgetBuddyContractsVersion = "1.3.4"
+  val budgetBuddyContractsVersion = "1.4.2"
 
   implementation("com.budgetbuddy:budget-buddy-contracts:${budgetBuddyContractsVersion}")
   implementation("org.springframework.boot:spring-boot-starter-webmvc")

--- a/src/integrationTest/java/com/budget/buddy/budget_buddy_api/BaseMvcIntegrationTest.java
+++ b/src/integrationTest/java/com/budget/buddy/budget_buddy_api/BaseMvcIntegrationTest.java
@@ -7,7 +7,6 @@ import com.budget.buddy.budget_buddy_contracts.generated.model.LoginRequest;
 import com.budget.buddy.budget_buddy_contracts.generated.model.RegisterRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
 import org.springframework.test.web.servlet.assertj.MvcTestResult;
@@ -41,7 +40,7 @@ public abstract class BaseMvcIntegrationTest extends BaseIntegrationTest {
         .content(json(new RegisterRequest().username(username).password(password)))
         .exchange();
 
-    assertThat(exchange).hasStatus(HttpStatus.CREATED);
+    assertThat(exchange).hasStatus2xxSuccessful();
   }
 
   protected AuthToken login(String username, String password) throws Exception {
@@ -50,7 +49,7 @@ public abstract class BaseMvcIntegrationTest extends BaseIntegrationTest {
         .content(json(new LoginRequest().username(username).password(password)))
         .exchange();
 
-    assertThat(exchange).hasStatus(HttpStatus.OK);
+    assertThat(exchange).hasStatus2xxSuccessful();
 
     return objectMapper.readValue(
         exchange.getResponse().getContentAsString(), AuthToken.class);

--- a/src/integrationTest/java/com/budget/buddy/budget_buddy_api/security/auth/AuthIntegrationTest.java
+++ b/src/integrationTest/java/com/budget/buddy/budget_buddy_api/security/auth/AuthIntegrationTest.java
@@ -71,7 +71,7 @@ class AuthIntegrationTest extends BaseMvcIntegrationTest {
 
       // Then
       assertThat(exchange)
-          .as("Registration should return 201 Created")
+          .as("Registration should return 204 No Content")
           .hasStatus(HttpStatus.NO_CONTENT);
     }
 

--- a/src/integrationTest/java/com/budget/buddy/budget_buddy_api/security/auth/AuthIntegrationTest.java
+++ b/src/integrationTest/java/com/budget/buddy/budget_buddy_api/security/auth/AuthIntegrationTest.java
@@ -72,7 +72,7 @@ class AuthIntegrationTest extends BaseMvcIntegrationTest {
       // Then
       assertThat(exchange)
           .as("Registration should return 201 Created")
-          .hasStatus(HttpStatus.CREATED);
+          .hasStatus(HttpStatus.NO_CONTENT);
     }
 
     @Test

--- a/src/integrationTest/java/com/budget/buddy/budget_buddy_api/security/auth/AuthIntegrationTest.java
+++ b/src/integrationTest/java/com/budget/buddy/budget_buddy_api/security/auth/AuthIntegrationTest.java
@@ -3,11 +3,11 @@ package com.budget.buddy.budget_buddy_api.security.auth;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.budget.buddy.budget_buddy_api.BaseMvcIntegrationTest;
+import com.budget.buddy.budget_buddy_api.security.refresh.token.TestRefreshTokenRepository;
 import com.budget.buddy.budget_buddy_contracts.generated.model.AuthToken;
 import com.budget.buddy.budget_buddy_contracts.generated.model.LoginRequest;
 import com.budget.buddy.budget_buddy_contracts.generated.model.RefreshTokenRequest;
 import com.budget.buddy.budget_buddy_contracts.generated.model.RegisterRequest;
-import com.budget.buddy.budget_buddy_api.security.refresh.token.TestRefreshTokenRepository;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -48,6 +48,19 @@ class AuthIntegrationTest extends BaseMvcIntegrationTest {
     assertThat(exchange)
         .as("Refresh request should be successful")
         .hasStatus(HttpStatus.OK);
+
+    return objectMapper.readValue(
+        exchange.getResponse().getContentAsString(), AuthToken.class);
+  }
+
+  @Override
+  protected AuthToken login(String username, String password) throws Exception {
+    var exchange = mvc.post().uri("/v1/auth/login")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(json(new LoginRequest().username(username).password(password)))
+        .exchange();
+
+    assertThat(exchange).hasStatus(HttpStatus.OK);
 
     return objectMapper.readValue(
         exchange.getResponse().getContentAsString(), AuthToken.class);

--- a/src/integrationTest/java/com/budget/buddy/budget_buddy_api/transaction/TransactionIntegrationTest.java
+++ b/src/integrationTest/java/com/budget/buddy/budget_buddy_api/transaction/TransactionIntegrationTest.java
@@ -283,6 +283,8 @@ class TransactionIntegrationTest extends BaseMvcIntegrationTest {
   @Nested
   class Update {
 
+    public static final Long AMOUNT = 2000L;
+
     @Test
     void should_UpdateTransaction_When_Owner() throws Exception {
       var created = createTransaction(userToken, userCategoryId);
@@ -290,12 +292,13 @@ class TransactionIntegrationTest extends BaseMvcIntegrationTest {
       var result = mvc.patch().uri("/v1/transactions/{id}", created.getId())
           .header(HttpHeaders.AUTHORIZATION, "Bearer " + userToken)
           .contentType(MediaType.APPLICATION_JSON)
-          .content(json(new TransactionUpdate().amount(2000)))
+          .content(json(new TransactionUpdate().amount(AMOUNT)))
           .exchange();
 
       assertThat(result).hasStatus(HttpStatus.OK);
       var updated = parseBody(result, Transaction.class);
-      assertThat(updated.getAmount()).isEqualTo(2000);
+      assertThat(updated)
+          .returns(AMOUNT, Transaction::getAmount);
     }
 
     @Test
@@ -331,7 +334,7 @@ class TransactionIntegrationTest extends BaseMvcIntegrationTest {
       var result = mvc.patch().uri("/v1/transactions/{id}", created.getId())
           .header(HttpHeaders.AUTHORIZATION, "Bearer " + userToken)
           .contentType(MediaType.APPLICATION_JSON)
-          .content(json(new TransactionUpdate().amount(9999)))
+          .content(json(new TransactionUpdate().amount(AMOUNT)))
           .exchange();
 
       assertThat(result).hasStatus(HttpStatus.NOT_FOUND);
@@ -343,7 +346,7 @@ class TransactionIntegrationTest extends BaseMvcIntegrationTest {
 
       var result = mvc.patch().uri("/v1/transactions/{id}", created.getId())
           .contentType(MediaType.APPLICATION_JSON)
-          .content(json(new TransactionUpdate().amount(9999)))
+          .content(json(new TransactionUpdate().amount(AMOUNT)))
           .exchange();
 
       assertThat(result).hasStatus(HttpStatus.UNAUTHORIZED);

--- a/src/integrationTest/java/com/budget/buddy/budget_buddy_api/transaction/TransactionRepositoryIntegrationTest.java
+++ b/src/integrationTest/java/com/budget/buddy/budget_buddy_api/transaction/TransactionRepositoryIntegrationTest.java
@@ -55,7 +55,7 @@ class TransactionRepositoryIntegrationTest extends BaseIntegrationTest {
   void shouldFilterTransactions(Direction direction) {
     // Given
     var t1 = new TransactionEntity();
-    t1.setAmount(100);
+    t1.setAmount(100L);
     t1.setCurrency(Currency.getInstance("USD"));
     t1.setType(TransactionType.EXPENSE);
     t1.setDate(LocalDate.now().minusDays(1));
@@ -64,7 +64,7 @@ class TransactionRepositoryIntegrationTest extends BaseIntegrationTest {
     transactionRepository.save(t1);
 
     var t2 = new TransactionEntity();
-    t2.setAmount(200);
+    t2.setAmount(200L);
     t2.setCurrency(Currency.getInstance("USD"));
     t2.setType(TransactionType.EXPENSE);
     t2.setDate(LocalDate.now());
@@ -88,7 +88,7 @@ class TransactionRepositoryIntegrationTest extends BaseIntegrationTest {
   void shouldCountByFilter() {
     // Given
     var t1 = new TransactionEntity();
-    t1.setAmount(100);
+    t1.setAmount(100L);
     t1.setCurrency(Currency.getInstance("USD"));
     t1.setType(TransactionType.EXPENSE);
     t1.setDate(LocalDate.now());
@@ -109,7 +109,7 @@ class TransactionRepositoryIntegrationTest extends BaseIntegrationTest {
   void shouldSaveAndFindByIdAndOwnerId() {
     // Given
     var transaction = new TransactionEntity();
-    transaction.setAmount(50);
+    transaction.setAmount(50L);
     transaction.setCurrency(Currency.getInstance("EUR"));
     transaction.setType(TransactionType.EXPENSE);
     transaction.setDate(LocalDate.now());
@@ -122,6 +122,6 @@ class TransactionRepositoryIntegrationTest extends BaseIntegrationTest {
 
     // Then
     assertThat(found).isPresent();
-    assertThat(found.get().getAmount()).isEqualTo(50);
+    assertThat(found.get().getAmount()).isEqualTo(50L);
   }
 }

--- a/src/main/java/com/budget/buddy/budget_buddy_api/security/auth/AuthController.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/security/auth/AuthController.java
@@ -7,7 +7,6 @@ import com.budget.buddy.budget_buddy_contracts.generated.model.RefreshTokenReque
 import com.budget.buddy.budget_buddy_contracts.generated.model.RegisterRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -35,7 +34,7 @@ public class AuthController implements AuthApi {
   @Override
   public ResponseEntity<Void> registerUser(RegisterRequest registerRequest) {
     authService.register(registerRequest);
-    return ResponseEntity.status(HttpStatus.CREATED).build();
+    return ResponseEntity.noContent().build();
   }
 
   @Override

--- a/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionController.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionController.java
@@ -5,8 +5,8 @@ import com.budget.buddy.budget_buddy_contracts.generated.api.TransactionsApi;
 import com.budget.buddy.budget_buddy_contracts.generated.model.PaginatedTransactions;
 import com.budget.buddy.budget_buddy_contracts.generated.model.PaginationMeta;
 import com.budget.buddy.budget_buddy_contracts.generated.model.Transaction;
-import com.budget.buddy.budget_buddy_contracts.generated.model.TransactionWrite;
 import com.budget.buddy.budget_buddy_contracts.generated.model.TransactionUpdate;
+import com.budget.buddy.budget_buddy_contracts.generated.model.TransactionWrite;
 import java.net.URI;
 import java.time.LocalDate;
 import java.util.UUID;
@@ -42,13 +42,9 @@ public class TransactionController
       UUID categoryId,
       LocalDate start,
       LocalDate end,
-      String order
+      String sort
   ) {
-    var sort = Direction.fromOptionalString(order)
-        .map(direction -> Sort.by(direction, "date"))
-        .orElse(DEFAULT_SORT);
-
-    var pageable = PageRequest.of(offset, limit, sort);
+    var pageable = PageRequest.of(offset, limit, buildSort(sort));
     var filter = TransactionFilter.of(categoryId, start, end);
     var items = service.list(filter, pageable);
     var total = service.count(filter);
@@ -92,4 +88,9 @@ public class TransactionController
     return URI.create("/v1/transactions/" + created.getId());
   }
 
+  private static Sort buildSort(String sortStr) {
+    return Direction.fromOptionalString(sortStr)
+        .map(direction -> Sort.by(direction, "date"))
+        .orElse(DEFAULT_SORT);
+  }
 }

--- a/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionEntity.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionEntity.java
@@ -31,7 +31,7 @@ public class TransactionEntity extends AuditableEntity implements OwnableEntity<
   private UUID categoryId;
 
   @Column("amount")
-  private Integer amount;
+  private Long amount;
 
   @Column("type")
   private TransactionType type;

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -17,3 +17,6 @@ databaseChangeLog:
   - include:
       file: migrations/006-hash-refresh-tokens.sql
       relativeToChangelogFile: true
+  - include:
+      file: migrations/007-transaction-amount-bigint.sql
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/migrations/007-transaction-amount-bigint.sql
+++ b/src/main/resources/db/changelog/migrations/007-transaction-amount-bigint.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+
+--changeset g.remniov@gmail.com:007-transaction-amount-bigint
+ALTER TABLE transactions
+    ALTER COLUMN amount TYPE BIGINT;
+
+--rollback ALTER TABLE transactions ALTER COLUMN amount TYPE INT;

--- a/src/test/java/com/budget/buddy/budget_buddy_api/transaction/TransactionMapperTest.java
+++ b/src/test/java/com/budget/buddy/budget_buddy_api/transaction/TransactionMapperTest.java
@@ -44,7 +44,7 @@ class TransactionMapperTest {
           .as("Mapped transaction entity should have correct values")
           .isNotNull()
           .returns(categoryId, TransactionEntity::getCategoryId)
-          .returns(1000, TransactionEntity::getAmount)
+          .returns(1000L, TransactionEntity::getAmount)
           .returns(TransactionType.EXPENSE, TransactionEntity::getType)
           .returns(Currency.getInstance("EUR"), TransactionEntity::getCurrency)
           .returns(date, TransactionEntity::getDate)
@@ -67,7 +67,7 @@ class TransactionMapperTest {
       var entity = new TransactionEntity(
           id,
           categoryId,
-          500,
+          500L,
           TransactionType.INCOME,
           Currency.getInstance("USD"),
           date,
@@ -104,8 +104,8 @@ class TransactionMapperTest {
       // Given
       var id1 = UUID.randomUUID();
       var id2 = UUID.randomUUID();
-      var e1 = new TransactionEntity(id1, UUID.randomUUID(), 100, TransactionType.EXPENSE, Currency.getInstance("EUR"), LocalDate.now(), "D1", UUID.randomUUID());
-      var e2 = new TransactionEntity(id2, UUID.randomUUID(), 200, TransactionType.INCOME, Currency.getInstance("USD"), LocalDate.now(), "D2", UUID.randomUUID());
+      var e1 = new TransactionEntity(id1, UUID.randomUUID(), 100L, TransactionType.EXPENSE, Currency.getInstance("EUR"), LocalDate.now(), "D1", UUID.randomUUID());
+      var e2 = new TransactionEntity(id2, UUID.randomUUID(), 200L, TransactionType.INCOME, Currency.getInstance("USD"), LocalDate.now(), "D2", UUID.randomUUID());
 
       // When
       var models = transactionMapper.toModelList(List.of(e1, e2));
@@ -137,10 +137,10 @@ class TransactionMapperTest {
       var categoryId = UUID.randomUUID();
       var ownerId = UUID.randomUUID();
       var date = LocalDate.now();
-      var entity = new TransactionEntity(originalId, categoryId, 100, TransactionType.EXPENSE, Currency.getInstance("EUR"), date, "Old Desc", ownerId);
+      var entity = new TransactionEntity(originalId, categoryId, 100L, TransactionType.EXPENSE, Currency.getInstance("EUR"), date, "Old Desc", ownerId);
 
       var update = new TransactionUpdate();
-      update.setAmount(500);
+      update.setAmount(500L);
       update.setDescription(JsonNullable.of("New Desc"));
 
       // When
@@ -149,7 +149,7 @@ class TransactionMapperTest {
       // Then
       assertThat(entity)
           .as("Updated entity should have correct updated and original values")
-          .returns(500, TransactionEntity::getAmount)
+          .returns(500L, TransactionEntity::getAmount)
           .returns("New Desc", TransactionEntity::getDescription)
           .returns(Currency.getInstance("EUR"), TransactionEntity::getCurrency)
           .returns(originalId, TransactionEntity::getId)
@@ -160,7 +160,7 @@ class TransactionMapperTest {
     @Test
     void should_NotUpdateIfNull() {
       // Given
-      var originalAmount = 100;
+      var originalAmount = 100L;
       var originalDesc = "Keep Me";
       var entity = new TransactionEntity(UUID.randomUUID(), UUID.randomUUID(), originalAmount, TransactionType.EXPENSE, Currency.getInstance("EUR"), LocalDate.now(), originalDesc, UUID.randomUUID());
 
@@ -182,7 +182,7 @@ class TransactionMapperTest {
     void should_ClearDescription_When_ExplicitJsonNullableInPatch() {
       // Given
       var entity = new TransactionEntity(
-          UUID.randomUUID(), UUID.randomUUID(), 100, TransactionType.EXPENSE,
+          UUID.randomUUID(), UUID.randomUUID(), 100L, TransactionType.EXPENSE,
           Currency.getInstance("EUR"), LocalDate.now(), "Old Description", UUID.randomUUID());
 
       var update = new TransactionUpdate();

--- a/src/test/java/com/budget/buddy/budget_buddy_api/transaction/TransactionValidatorTest.java
+++ b/src/test/java/com/budget/buddy/budget_buddy_api/transaction/TransactionValidatorTest.java
@@ -26,7 +26,7 @@ class TransactionValidatorTest {
   TransactionEntity validEntity(UUID categoryId) {
     var entity = new TransactionEntity();
     entity.setCategoryId(categoryId);
-    entity.setAmount(1299);
+    entity.setAmount(1299L);
     entity.setCurrency(Currency.getInstance("EUR"));
     return entity;
   }


### PR DESCRIPTION
This PR aligns the API implementation with the latest version of `budget-buddy-contracts` (v1.4.2).

### Changes
- **Dependency Update:** Upgraded `budget-buddy-contracts` to `1.4.2`.
- **Transactions:**
  - Changed `amount` field from `Integer` to `Long` in `TransactionEntity` and all related layers to support larger values and match the contract.
  - Added Liquibase migration (`007-transaction-amount-bigint.sql`) to update the `amount` column type in the database.
  - Renamed `listTransactions` parameter `order` to `sort` to match the OpenAPI specification.
- **Authentication:**
  - Refactored `AuthController.registerUser` to return `204 No Content` instead of `201 Created` for compliance with the contract.
- **Tests:**
  - Updated integration and unit tests to reflect the new amount type and status codes.

### Closes
- Closes #90
- Closes #91
- Closes #93