### PR TITLE
fix(ci): approve esbuild build scripts for pnpm v10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,7 +83,7 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6
         with:
           version: 10
 

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -14,7 +14,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6
         with:
           version: 10
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "budget-buddy-api",
-  "version": "0.0.0-semantic-release",
   "private": true,
   "devDependencies": {
     "@commitlint/cli": "^20.5.0",
@@ -10,7 +9,7 @@
     "@semantic-release/exec": "^7.1.0",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^12.0.6",
-    "@semantic-release/release-notes-generator": "^14.0.3",
+    "@semantic-release/release-notes-generator": "^14.1.0",
     "semantic-release": "^25.0.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,7 @@ importers:
         specifier: ^12.0.6
         version: 12.0.6(semantic-release@25.0.3(typescript@6.0.2))
       '@semantic-release/release-notes-generator':
-        specifier: ^14.0.3
+        specifier: ^14.1.0
         version: 14.1.0(semantic-release@25.0.3(typescript@6.0.2))
       semantic-release:
         specifier: ^25.0.3


### PR DESCRIPTION
pnpm v10 requires explicit approval for packages that run postinstall scripts. esbuild (transitive dep of Vite) downloads platform binaries via postinstall and must be in onlyBuiltDependencies, otherwise `pnpm install --frozen-lockfile` exits with ERR_PNPM_IGNORED_BUILDS.