### PR TITLE
test(auth): restore username length integration test

### DIFF
--- a/src/integrationTest/java/com/budget/buddy/budget_buddy_api/security/auth/AuthIntegrationTest.java
+++ b/src/integrationTest/java/com/budget/buddy/budget_buddy_api/security/auth/AuthIntegrationTest.java
@@ -142,6 +142,25 @@ class AuthIntegrationTest extends BaseMvcIntegrationTest {
           .as("Password '%s' should be rejected with 400 Bad Request, reason: %s", password, reason)
           .hasStatus(HttpStatus.BAD_REQUEST);
     }
+
+    @Test
+    void should_Return400_When_UsernameTooShort() {
+      // Given
+      var request = new RegisterRequest()
+          .username("ab")
+          .password(STRONG_TEST_PASSWORD);
+
+      // When
+      var exchange = mvc.post().uri("/v1/auth/register")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(json(request))
+          .exchange();
+
+      // Then
+      assertThat(exchange)
+          .as("Registration with too-short username should return 400 Bad Request")
+          .hasStatus(HttpStatus.BAD_REQUEST);
+    }
   }
 
   @Nested


### PR DESCRIPTION
## Why

The `should_Return400_When_UsernameTooShort` test was silently dropped during the password-complexity refactor (#86). The `RegisterRequest` contract enforces `@Size(min=3)` on the `username` field, so the behavior was never broken — but it lost its integration-level coverage.

## What changed

- Restored `should_Return400_When_UsernameTooShort` in `AuthIntegrationTest.Register` as a standalone `@Test`
- Uses `STRONG_TEST_PASSWORD` so the assertion targets username validation only, not password complexity

## How to verify

```bash
./gradlew integrationTest --tests "com.budget.buddy.budget_buddy_api.security.auth.AuthIntegrationTest"
```

All tests should pass, including the restored case.