### PR TITLE
standardize service read methods with @Transactional(readOnly = true)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,9 @@ Or add `gpr.user` / `gpr.key` to `~/.gradle/gradle.properties`.
 - **Validation Handling**:
   - Prefer using `ex.getBindingResult().getFieldErrors()` for `MethodArgumentNotValidException`.
   - Prefer using `ex.getConstraintViolations()` for `ConstraintViolationException`.
+- **Transactional Methods**:
+  - **Read-Only Operations**: All service-level read operations (e.g., `read`, `list`, `count`) MUST be marked with `@Transactional(readOnly = true)`.
+  - **Class-Level Default**: Prefer setting `@Transactional(readOnly = true)` at the class level and overriding it with `@Transactional` on specific write methods (create, update, delete).
 
 ---
 

--- a/src/main/java/com/budget/buddy/budget_buddy_api/base/crudl/base/AbstractBaseEntityService.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/base/crudl/base/AbstractBaseEntityService.java
@@ -17,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @param <U> Update request type (DTO)
  */
 @Slf4j
-@Transactional
+@Transactional(readOnly = true)
 public abstract class AbstractBaseEntityService<E extends BaseEntity<ID>, ID, R, C, U>
     implements BaseEntityService<ID, R, C, U> {
 
@@ -44,6 +44,7 @@ public abstract class AbstractBaseEntityService<E extends BaseEntity<ID>, ID, R,
     this.validators = validators;
   }
 
+  @Transactional
   @Override
   public R create(C createRequest) {
     log.debug("Create entity: {}", createRequest);
@@ -52,7 +53,6 @@ public abstract class AbstractBaseEntityService<E extends BaseEntity<ID>, ID, R,
     return mapper.toModel(savedEntity);
   }
 
-  @Transactional(readOnly = true)
   @Override
   public R read(ID id) {
     log.debug("Read entity by id: {}", id);
@@ -60,6 +60,7 @@ public abstract class AbstractBaseEntityService<E extends BaseEntity<ID>, ID, R,
     return mapper.toModel(entity);
   }
 
+  @Transactional
   @Override
   public R update(ID id, U patchRequest) {
     log.debug("Update entity by id: {}", id);
@@ -68,6 +69,7 @@ public abstract class AbstractBaseEntityService<E extends BaseEntity<ID>, ID, R,
     return mapper.toModel(updatedEntity);
   }
 
+  @Transactional
   @Override
   public R replace(ID id, C replaceRequest) {
     log.debug("Replace entity by id: {}", id);
@@ -76,6 +78,7 @@ public abstract class AbstractBaseEntityService<E extends BaseEntity<ID>, ID, R,
     return mapper.toModel(replacedEntity);
   }
 
+  @Transactional
   @Override
   public void delete(ID id) {
     log.debug("Delete entity by id: {}", id);
@@ -83,7 +86,6 @@ public abstract class AbstractBaseEntityService<E extends BaseEntity<ID>, ID, R,
     log.debug("Successfully deleted entity with id: {}", id);
   }
 
-  @Transactional(readOnly = true)
   @Override
   public List<R> list() {
     log.debug("List all entities");
@@ -92,7 +94,6 @@ public abstract class AbstractBaseEntityService<E extends BaseEntity<ID>, ID, R,
     return mapper.toModelList(entities);
   }
 
-  @Transactional(readOnly = true)
   @Override
   public Page<R> list(Pageable pageable) {
     log.debug("List all entities with pageRequest: {}", pageable);
@@ -100,7 +101,6 @@ public abstract class AbstractBaseEntityService<E extends BaseEntity<ID>, ID, R,
         .map(mapper::toModel);
   }
 
-  @Transactional(readOnly = true)
   @Override
   public long count() {
     log.debug("Count all entities");
@@ -128,6 +128,7 @@ public abstract class AbstractBaseEntityService<E extends BaseEntity<ID>, ID, R,
    * @param createRequest the create request
    * @return the created entity
    */
+  @Transactional
   protected E createInternal(C createRequest) {
     E entity = mapper.toEntity(createRequest);
     validate(entity);
@@ -153,6 +154,7 @@ public abstract class AbstractBaseEntityService<E extends BaseEntity<ID>, ID, R,
    * @param updateRequest the update request
    * @return the updated entity
    */
+  @Transactional
   protected E updateInternal(ID id, U updateRequest) {
     E existingEntity = readInternal(id);
     mapper.patchEntity(updateRequest, existingEntity);
@@ -167,6 +169,7 @@ public abstract class AbstractBaseEntityService<E extends BaseEntity<ID>, ID, R,
    * @param replaceRequest the replace request
    * @return the replaced entity
    */
+  @Transactional
   protected E replaceInternal(ID id, C replaceRequest) {
     E existingEntity = readInternal(id);
     mapper.replaceEntity(replaceRequest, existingEntity);
@@ -179,6 +182,7 @@ public abstract class AbstractBaseEntityService<E extends BaseEntity<ID>, ID, R,
    *
    * @param id the unique identifier
    */
+  @Transactional
   protected void deleteInternal(ID id) {
     var entity = readInternal(id);
     repository.delete(entity);

--- a/src/main/java/com/budget/buddy/budget_buddy_api/base/crudl/ownable/OwnableEntityService.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/base/crudl/ownable/OwnableEntityService.java
@@ -8,6 +8,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Base class for services managing entities that belong to a specific owner.
@@ -51,12 +52,14 @@ public class OwnableEntityService<E extends OwnableEntity<ID>, ID, R, C, U>
     return repository.findAllByOwnerId(ownerIdProvider.get(), pageRequest);
   }
 
+  @Transactional
   @Override
   protected void deleteInternal(ID id) {
     var entity = readInternal(id);
     repository.delete(entity);
   }
 
+  @Transactional
   @Override
   protected E updateInternal(ID id, U updateRequest) {
     E existingEntity = readInternal(id);
@@ -65,6 +68,7 @@ public class OwnableEntityService<E extends OwnableEntity<ID>, ID, R, C, U>
     return repository.save(existingEntity);
   }
 
+  @Transactional
   @Override
   protected E replaceInternal(ID id, C replaceRequest) {
     E existingEntity = readInternal(id);
@@ -84,6 +88,7 @@ public class OwnableEntityService<E extends OwnableEntity<ID>, ID, R, C, U>
     return repository.existsByIdAndOwnerId(id, ownerIdProvider.get());
   }
 
+  @Transactional
   @Override
   protected E createInternal(C createRequest) {
     E entity = mapper.toEntity(createRequest);

--- a/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionService.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionService.java
@@ -11,10 +11,12 @@ import java.util.Set;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Service for managing user transactions. Extends {@link OwnableEntityService} to provide basic CRUD operations and includes custom filtering for transactions.
  */
+@Transactional(readOnly = true)
 @Service
 public class TransactionService extends
     OwnableEntityService<TransactionEntity, UUID, Transaction, TransactionWrite, TransactionUpdate> {

--- a/src/main/java/com/budget/buddy/budget_buddy_api/user/UserService.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/user/UserService.java
@@ -17,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * Service for managing users.
  */
-@Transactional
+@Transactional(readOnly = true)
 @Service
 public class UserService extends AbstractBaseEntityService<UserEntity, UUID, UserDto, RegisterRequest, Object> {
 
@@ -66,11 +66,13 @@ public class UserService extends AbstractBaseEntityService<UserEntity, UUID, Use
     return savedUser;
   }
 
+  @Transactional
   @Override
   public UserDto update(UUID uuid, Object patchRequest) throws EntityNotFoundException {
     throw new UnsupportedOperationException();
   }
 
+  @Transactional
   @Override
   public void delete(UUID uuid) throws EntityNotFoundException {
     throw new UnsupportedOperationException();


### PR DESCRIPTION
## Why

Read operations in service classes were either non-transactional or use the default `@Transactional` (read-write). Marking them `readOnly = true` allows database optimizations and prevents accidental writes. Closes #84.

## What changed

- **AbstractBaseEntityService.java**: Changed class-level annotation to `@Transactional(readOnly = true)` and explicitly marked write methods (`create`, `update`, `replace`, `delete` and their `Internal` counterparts) with `@Transactional`.
- **OwnableEntityService.java**: Added `@Transactional` to overridden write `Internal` methods. Inherits class-level `readOnly = true`.
- **UserService.java**: Updated to use `@Transactional(readOnly = true)` at class level and overridden write methods with `@Transactional`.
- **TransactionService.java**: Added `@Transactional(readOnly = true)` at class level.
- **AGENTS.md**: Updated with the new convention for transactional methods.

## Acceptance criteria

- Mark read-only methods (`getById`, `list`, etc.) in `AbstractBaseEntityService`, `OwnableEntityService`, and domain services with `@Transactional(readOnly = true)`: ✅ (Implemented via class-level defaults and explicit overrides)

## How to verify

1. Run `./gradlew check` to ensure all tests still pass and there are no compilation errors.
2. Review the changes to ensure all write operations still have `@Transactional` (read-write).

## Notes

Used class-level `@Transactional(readOnly = true)` as a safer and more maintainable pattern for services that primarily perform reads.