### PR TITLE
feat: add JIT user provisioning for OIDC authentication (#118)

### DIFF
--- a/src/integrationTest/java/com/budget/buddy/budget_buddy_api/BaseMvcIntegrationTest.java
+++ b/src/integrationTest/java/com/budget/buddy/budget_buddy_api/BaseMvcIntegrationTest.java
@@ -1,7 +1,5 @@
 package com.budget.buddy.budget_buddy_api;
 
-import com.budget.buddy.budget_buddy_api.user.UserEntity;
-import com.budget.buddy.budget_buddy_api.user.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
@@ -22,9 +20,6 @@ public abstract class BaseMvcIntegrationTest extends BaseIntegrationTest {
   @Autowired
   protected MockMvcTester mvc;
 
-  @Autowired
-  private UserRepository userRepository;
-
   protected String json(Object obj) {
     return objectMapper.writeValueAsString(obj);
   }
@@ -34,23 +29,18 @@ public abstract class BaseMvcIntegrationTest extends BaseIntegrationTest {
   }
 
   /**
-   * Creates a test user in the database and returns their ID.
+   * Creates a unique OIDC subject for test isolation.
+   * The provisioning filter will auto-create the local user on first request.
    */
   protected String createTestUser() {
-    var user = UserEntity.builder()
-        .username("testuser-" + UUID.randomUUID())
-        .oidcSubject("sub-" + UUID.randomUUID())
-        .enabled(true)
-        .build();
-    var saved = userRepository.save(user);
-    return saved.getId().toString();
+    return "test-sub-" + UUID.randomUUID();
   }
 
   /**
-   * Returns a JWT request post-processor for the given user ID.
+   * Returns a JWT request post-processor for the given OIDC subject.
    */
-  protected static RequestPostProcessor jwtForUser(String userId) {
-    return jwt().jwt(j -> j.subject(userId));
+  protected static RequestPostProcessor jwtForUser(String oidcSubject) {
+    return jwt().jwt(j -> j.subject(oidcSubject));
   }
 
 }

--- a/src/integrationTest/java/com/budget/buddy/budget_buddy_api/security/oidc/OidcUserProvisioningIntegrationTest.java
+++ b/src/integrationTest/java/com/budget/buddy/budget_buddy_api/security/oidc/OidcUserProvisioningIntegrationTest.java
@@ -1,0 +1,142 @@
+package com.budget.buddy.budget_buddy_api.security.oidc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+
+import com.budget.buddy.budget_buddy_api.BaseMvcIntegrationTest;
+import com.budget.buddy.budget_buddy_api.user.UserRepository;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+@DisplayName("OIDC User Provisioning Integration Tests")
+class OidcUserProvisioningIntegrationTest extends BaseMvcIntegrationTest {
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Test
+  @DisplayName("should provision a new user on first authenticated request")
+  void shouldProvisionNewUserOnFirstRequest() {
+    var oidcSubject = "test-sub-" + UUID.randomUUID();
+
+    // First request — user does not exist yet
+    assertThat(userRepository.findByOidcSubject(oidcSubject)).isEmpty();
+
+    var result = mvc.get().uri("/v1/categories")
+        .with(jwtForUser(oidcSubject))
+        .exchange();
+
+    assertThat(result.getResponse().getStatus()).isEqualTo(HttpStatus.OK.value());
+
+    // User should now exist in the database
+    var user = userRepository.findByOidcSubject(oidcSubject);
+    assertThat(user).isPresent();
+    assertThat(user.get().getOidcSubject()).isEqualTo(oidcSubject);
+    assertThat(user.get().isEnabled()).isTrue();
+  }
+
+  @Test
+  @DisplayName("should reuse existing user on subsequent requests")
+  void shouldReuseExistingUserOnSubsequentRequests() {
+    var oidcSubject = "test-sub-" + UUID.randomUUID();
+
+    // First request — provisions the user
+    mvc.get().uri("/v1/categories")
+        .with(jwtForUser(oidcSubject))
+        .exchange();
+
+    var firstUser = userRepository.findByOidcSubject(oidcSubject);
+    assertThat(firstUser).isPresent();
+    var userId = firstUser.get().getId();
+
+    // Second request — should reuse the same user
+    mvc.get().uri("/v1/categories")
+        .with(jwtForUser(oidcSubject))
+        .exchange();
+
+    var secondUser = userRepository.findByOidcSubject(oidcSubject);
+    assertThat(secondUser).isPresent();
+    assertThat(secondUser.get().getId()).isEqualTo(userId);
+  }
+
+  @Test
+  @DisplayName("should use preferred_username from JWT claims as username")
+  void shouldUsePreferredUsernameFromJwtClaims() {
+    var oidcSubject = "test-sub-" + UUID.randomUUID();
+
+    mvc.get().uri("/v1/categories")
+        .with(jwt().jwt(j -> j
+            .subject(oidcSubject)
+            .claim("preferred_username", "johndoe")))
+        .exchange();
+
+    var user = userRepository.findByOidcSubject(oidcSubject);
+    assertThat(user).isPresent();
+    assertThat(user.get().getUsername()).isEqualTo("johndoe");
+  }
+
+  @Test
+  @DisplayName("should fall back to email when preferred_username is absent")
+  void shouldFallBackToEmailWhenPreferredUsernameAbsent() {
+    var oidcSubject = "test-sub-" + UUID.randomUUID();
+
+    mvc.get().uri("/v1/categories")
+        .with(jwt().jwt(j -> j
+            .subject(oidcSubject)
+            .claim("email", "john@example.com")))
+        .exchange();
+
+    var user = userRepository.findByOidcSubject(oidcSubject);
+    assertThat(user).isPresent();
+    assertThat(user.get().getUsername()).isEqualTo("john@example.com");
+  }
+
+  @Test
+  @DisplayName("should fall back to subject when no username claims are present")
+  void shouldFallBackToSubjectWhenNoUsernameClaims() {
+    var oidcSubject = "test-sub-" + UUID.randomUUID();
+
+    mvc.get().uri("/v1/categories")
+        .with(jwt().jwt(j -> j.subject(oidcSubject)))
+        .exchange();
+
+    var user = userRepository.findByOidcSubject(oidcSubject);
+    assertThat(user).isPresent();
+    assertThat(user.get().getUsername()).isEqualTo(oidcSubject);
+  }
+
+  @Test
+  @DisplayName("should reject unauthenticated requests")
+  void shouldRejectUnauthenticatedRequests() {
+    var result = mvc.get().uri("/v1/categories")
+        .exchange();
+
+    assertThat(result.getResponse().getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+  }
+
+  @Test
+  @DisplayName("should isolate data between different OIDC subjects")
+  void shouldIsolateDataBetweenDifferentSubjects() {
+    var subject1 = "test-sub-" + UUID.randomUUID();
+    var subject2 = "test-sub-" + UUID.randomUUID();
+
+    // Both make requests
+    mvc.get().uri("/v1/categories")
+        .with(jwtForUser(subject1))
+        .exchange();
+    mvc.get().uri("/v1/categories")
+        .with(jwtForUser(subject2))
+        .exchange();
+
+    // Both should have separate user records
+    var user1 = userRepository.findByOidcSubject(subject1);
+    var user2 = userRepository.findByOidcSubject(subject2);
+
+    assertThat(user1).isPresent();
+    assertThat(user2).isPresent();
+    assertThat(user1.get().getId()).isNotEqualTo(user2.get().getId());
+  }
+}

--- a/src/main/java/com/budget/buddy/budget_buddy_api/base/config/ApplicationConfig.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/base/config/ApplicationConfig.java
@@ -1,12 +1,16 @@
 package com.budget.buddy.budget_buddy_api.base.config;
 
 import com.budget.buddy.budget_buddy_api.base.crudl.ownable.OwnerIdProvider;
-import com.budget.buddy.budget_buddy_api.security.auth.AuthUtils;
+import com.budget.buddy.budget_buddy_api.security.oidc.OidcUserProvisioningFilter;
+import jakarta.servlet.http.HttpServletRequest;
 import java.time.Clock;
 import java.util.UUID;
 import java.util.function.Supplier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.server.resource.InvalidBearerTokenException;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 @Configuration
 public class ApplicationConfig {
@@ -22,14 +26,24 @@ public class ApplicationConfig {
   }
 
   /**
-   * Provides the ID of the currently authenticated user by reading the JWT subject from the
-   * active security context.
-   *
-   * @return an {@link OwnerIdProvider} backed by the current request's security context
+   * Provides the local user UUID set by {@link OidcUserProvisioningFilter}.
+   * The filter runs after JWT authentication and maps the OIDC subject to a local user,
+   * storing the resulting UUID as a request attribute.
    */
   @Bean
   OwnerIdProvider<UUID> ownerIdProvider() {
-    return () -> AuthUtils.requireCurrentUserId(UUID::fromString);
+    return () -> {
+      var attrs = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+      if (attrs == null) {
+        throw new InvalidBearerTokenException("No request context available.");
+      }
+      HttpServletRequest request = attrs.getRequest();
+      var userId = (UUID) request.getAttribute(OidcUserProvisioningFilter.USER_ID_ATTRIBUTE);
+      if (userId == null) {
+        throw new InvalidBearerTokenException("Current user is not authenticated.");
+      }
+      return userId;
+    };
   }
 
 }

--- a/src/main/java/com/budget/buddy/budget_buddy_api/base/crudl/ownable/OwnerIdProvider.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/base/crudl/ownable/OwnerIdProvider.java
@@ -6,9 +6,9 @@ import org.springframework.security.core.AuthenticationException;
 /**
  * Resolves the ID of the currently authenticated owner.
  *
- * <p>Implementations are expected to read the identity from the active security context.
- * The production binding lives in {@code ApplicationConfig} and delegates to
- * {@link com.budget.buddy.budget_buddy_api.security.auth.AuthUtils}.
+ * <p>Implementations are expected to read the identity from the active request context.
+ * The production binding lives in {@code ApplicationConfig} and reads the user ID
+ * set by {@link com.budget.buddy.budget_buddy_api.security.oidc.OidcUserProvisioningFilter}.
  *
  * @param <ID> the owner identifier type
  */

--- a/src/main/java/com/budget/buddy/budget_buddy_api/security/SecurityConfig.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/security/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.budget.buddy.budget_buddy_api.security;
 
+import com.budget.buddy.budget_buddy_api.security.oidc.OidcUserProvisioningFilter;
+import com.budget.buddy.budget_buddy_api.user.UserService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -7,6 +9,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfigurationSource;
 
@@ -20,7 +23,11 @@ import org.springframework.web.cors.CorsConfigurationSource;
 public class SecurityConfig {
 
   @Bean
-  SecurityFilterChain securityFilterChain(HttpSecurity http, CorsConfigurationSource corsConfigurationSource) {
+  SecurityFilterChain securityFilterChain(
+      HttpSecurity http,
+      CorsConfigurationSource corsConfigurationSource,
+      UserService userService
+  ) {
     http
         .cors(cors -> cors.configurationSource(corsConfigurationSource))
         .authorizeHttpRequests(auth -> auth
@@ -28,6 +35,7 @@ public class SecurityConfig {
             .anyRequest().authenticated()
         )
         .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
+        .addFilterAfter(new OidcUserProvisioningFilter(userService), BearerTokenAuthenticationFilter.class)
         .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .httpBasic(AbstractHttpConfigurer::disable)
         .csrf(csrf -> csrf.ignoringRequestMatchers("/v1/**", "/actuator/**"))

--- a/src/main/java/com/budget/buddy/budget_buddy_api/security/oidc/OidcUserProvisioningFilter.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/security/oidc/OidcUserProvisioningFilter.java
@@ -1,0 +1,47 @@
+package com.budget.buddy.budget_buddy_api.security.oidc;
+
+import com.budget.buddy.budget_buddy_api.user.UserService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Ensures a local {@code UserEntity} exists for every authenticated OIDC user.
+ * On the first request from a new user, a record is created automatically (JIT provisioning).
+ * The resolved local user ID is stored as a request attribute for downstream use by
+ * {@link com.budget.buddy.budget_buddy_api.base.crudl.ownable.OwnerIdProvider}.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class OidcUserProvisioningFilter extends OncePerRequestFilter {
+
+  /**
+   * Request attribute key where the local user UUID is stored after provisioning.
+   */
+  public static final String USER_ID_ATTRIBUTE = OidcUserProvisioningFilter.class.getName() + ".USER_ID";
+
+  private final UserService userService;
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+
+    var authentication = SecurityContextHolder.getContext().getAuthentication();
+
+    if (authentication != null && authentication.getPrincipal() instanceof Jwt jwt) {
+      var oidcSubject = jwt.getSubject();
+      UUID localUserId = userService.findOrCreateByOidcSubject(oidcSubject, jwt);
+      request.setAttribute(USER_ID_ATTRIBUTE, localUserId);
+    }
+
+    filterChain.doFilter(request, response);
+  }
+}

--- a/src/main/java/com/budget/buddy/budget_buddy_api/user/UserService.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/user/UserService.java
@@ -8,15 +8,18 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Service for managing users.
  */
+@Slf4j
 @Transactional(readOnly = true)
 @Service
 public class UserService extends AbstractBaseEntityService<UserEntity, UUID, UserDto, RegisterRequest, Object> {
@@ -64,6 +67,41 @@ public class UserService extends AbstractBaseEntityService<UserEntity, UUID, Use
   public Optional<UserDto> findByOidcSubject(String oidcSubject) {
     return repository.findByOidcSubject(oidcSubject)
         .map(mapper::toModel);
+  }
+
+  /**
+   * Finds or creates a local user for the given OIDC subject.
+   * On first login, a new user is provisioned automatically (JIT provisioning).
+   *
+   * @param oidcSubject the OIDC subject identifier (JWT sub claim)
+   * @param jwt the JWT token, used to extract display name for new users
+   * @return the local user's UUID
+   */
+  @Transactional
+  public UUID findOrCreateByOidcSubject(String oidcSubject, Jwt jwt) {
+    return repository.findByOidcSubject(oidcSubject)
+        .map(UserEntity::getId)
+        .orElseGet(() -> {
+          log.info("Provisioning new user for OIDC subject: {}", oidcSubject);
+          var user = UserEntity.builder()
+              .oidcSubject(oidcSubject)
+              .username(resolveUsername(jwt))
+              .enabled(true)
+              .build();
+          return repository.save(user).getId();
+        });
+  }
+
+  private static String resolveUsername(Jwt jwt) {
+    var preferred = jwt.getClaimAsString("preferred_username");
+    if (preferred != null && !preferred.isBlank()) {
+      return preferred;
+    }
+    var email = jwt.getClaimAsString("email");
+    if (email != null && !email.isBlank()) {
+      return email;
+    }
+    return jwt.getSubject();
   }
 
   @Transactional


### PR DESCRIPTION
## Summary

- Add `OidcUserProvisioningFilter` that runs after JWT validation and automatically creates a local user record on first authenticated request (JIT provisioning)
- Update `OwnerIdProvider` to read the provisioned user UUID from a request attribute instead of parsing the JWT directly
- Add `UserService.findOrCreateByOidcSubject()` with username resolution from `preferred_username` → `email` → `sub` JWT claims

## Test plan

- [x] Unit tests pass (`./gradlew test`)
- [x] Integration tests pass (`./gradlew integrationTest`)
- [x] Full quality gate passes (`./gradlew check`)
- [x] Dedicated `OidcUserProvisioningIntegrationTest` covers:
  - New user provisioning on first request
  - Existing user reuse on subsequent requests
  - Username resolution from `preferred_username`, `email`, and `sub` claims
  - Unauthenticated request rejection
  - Data isolation between different OIDC subjects

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)