### PR TITLE
fix(security): add JWT audience/scope validation, HTTP headers, and reduce cache TTL

### DIFF
--- a/src/integrationTest/java/com/budget/buddy/budget_buddy_api/BaseMvcIntegrationTest.java
+++ b/src/integrationTest/java/com/budget/buddy/budget_buddy_api/BaseMvcIntegrationTest.java
@@ -9,6 +9,8 @@ import tools.jackson.databind.ObjectMapper;
 
 import java.util.UUID;
 
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 
 @AutoConfigureMockMvc
@@ -40,7 +42,9 @@ public abstract class BaseMvcIntegrationTest extends BaseIntegrationTest {
    * Returns a JWT request post-processor for the given OIDC subject.
    */
   protected static RequestPostProcessor jwtForUser(String oidcSubject) {
-    return jwt().jwt(j -> j.subject(oidcSubject));
+    return jwt()
+        .jwt(j -> j.subject(oidcSubject))
+        .authorities(new SimpleGrantedAuthority("SCOPE_openid"));
   }
 
 }

--- a/src/integrationTest/java/com/budget/buddy/budget_buddy_api/TestSecurityConfig.java
+++ b/src/integrationTest/java/com/budget/buddy/budget_buddy_api/TestSecurityConfig.java
@@ -2,6 +2,7 @@ package com.budget.buddy.budget_buddy_api;
 
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 
@@ -18,6 +19,7 @@ public class TestSecurityConfig {
   private static final String TEST_SECRET = "integration-test-secret-key-that-is-at-least-32-chars";
 
   @Bean
+  @Primary
   JwtDecoder jwtDecoder() {
     var key = new SecretKeySpec(TEST_SECRET.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
     return NimbusJwtDecoder.withSecretKey(key).build();

--- a/src/main/java/com/budget/buddy/budget_buddy_api/security/SecurityConfig.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/security/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.budget.buddy.budget_buddy_api.security;
 
 import com.budget.buddy.budget_buddy_api.security.oidc.OidcUserProvisioningFilter;
 import com.budget.buddy.budget_buddy_api.user.UserService;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -9,18 +10,39 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.jwt.JwtClaimNames;
+import org.springframework.security.oauth2.jwt.JwtClaimValidator;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
 import org.springframework.web.cors.CorsConfigurationSource;
 
-/**
- * Security configuration for the application.
- * The API is a stateless OIDC resource server — all authentication is handled
- * by the external OIDC provider. JWTs are validated against the configured issuer.
- */
+import java.util.List;
+
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+
+  @Bean
+  JwtDecoder jwtDecoder(
+      @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}") String issuerUri,
+      @Value("${security.oidc.audience}") String audience
+  ) {
+    NimbusJwtDecoder decoder = NimbusJwtDecoder
+        .withIssuerLocation(issuerUri)
+        .build();
+
+    var withIssuer = JwtValidators.createDefaultWithIssuer(issuerUri);
+    var withAudience = new JwtClaimValidator<List<String>>(JwtClaimNames.AUD,
+        aud -> aud != null && aud.contains(audience));
+
+    decoder.setJwtValidator(new DelegatingOAuth2TokenValidator<>(withIssuer, withAudience));
+    return decoder;
+  }
 
   @Bean
   SecurityFilterChain securityFilterChain(
@@ -32,14 +54,23 @@ public class SecurityConfig {
         .cors(cors -> cors.configurationSource(corsConfigurationSource))
         .authorizeHttpRequests(auth -> auth
             .requestMatchers("/actuator/health").permitAll()
-            .anyRequest().authenticated()
+            .anyRequest().hasAuthority("SCOPE_openid")
         )
         .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
         .addFilterAfter(new OidcUserProvisioningFilter(userService), BearerTokenAuthenticationFilter.class)
         .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .httpBasic(AbstractHttpConfigurer::disable)
         .csrf(csrf -> csrf.ignoringRequestMatchers("/v1/**", "/actuator/**"))
-        .formLogin(AbstractHttpConfigurer::disable);
+        .formLogin(AbstractHttpConfigurer::disable)
+        .headers(headers -> headers
+            .httpStrictTransportSecurity(hsts -> hsts
+                .includeSubDomains(true)
+                .maxAgeInSeconds(31536000))
+            .frameOptions(frame -> frame.deny())
+            .contentTypeOptions(Customizer.withDefaults())
+            .referrerPolicy(referrer -> referrer
+                .policy(ReferrerPolicyHeaderWriter.ReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN))
+        );
 
     return http.build();
   }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -17,12 +17,14 @@ spring:
       spec: >
         initialCapacity=50,
         maximumSize=200,
-        expireAfterWrite=24h
+        expireAfterWrite=${OIDC_USER_CACHE_TTL:5m}
 
 server:
   port: ${SERVER_PORT:8080}
 
 security:
+  oidc:
+    audience: ${OIDC_API_AUDIENCE}
   cors:
     allowed-origin-patterns: [ ]
     allowed-methods: [ GET, POST, PUT, PATCH, DELETE, OPTIONS ]


### PR DESCRIPTION
## Summary

- **#130** — Register custom `JwtDecoder` bean with `aud` claim validation via `JwtClaimValidator`. Adds `OIDC_API_AUDIENCE` env var (required, no default). Any JWT not containing this audience will be rejected with 401, regardless of issuer.
- **#131** — Replace `anyRequest().authenticated()` with `anyRequest().hasAuthority("SCOPE_openid")`. Tokens lacking the `openid` scope are now rejected with 403.
- **#80 / #3** — Add explicit HTTP security headers to the filter chain: HSTS (1 year + subdomains), `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`.
- **#132** — Reduce OIDC user provisioning Caffeine cache TTL from 24h to 5m (configurable via `OIDC_USER_CACHE_TTL` env var). Bounds the window between IdP revocation and API enforcement.

## Test plan

- [ ] `TestSecurityConfig` now has `@Primary` so it overrides the production `JwtDecoder` bean in tests
- [ ] `jwtForUser()` in `BaseMvcIntegrationTest` now sets `SCOPE_openid` authority — all existing integration tests should still pass
- [ ] Verify `OIDC_API_AUDIENCE` is set in your deployment `.env` (see budget-buddy-org/budget-buddy-deployment#3)
- [ ] Run integration tests: `./gradlew integrationTest`

## Notes

- HSTS header is only effective over HTTPS. Safe to include in all environments — browsers ignore it over HTTP.
- Deployment-side change (adding `OIDC_API_AUDIENCE` to `docker-compose.yml` and `.env.example`) tracked in budget-buddy-org/budget-buddy-deployment#3.

Closes #130
Closes #131
Closes #80
Closes #3
Closes #132