### PR TITLE
fix: enforce maximum page size of 500 on list endpoints

### DIFF
--- a/src/integrationTest/java/com/budget/buddy/budget_buddy_api/category/CategoryIntegrationTest.java
+++ b/src/integrationTest/java/com/budget/buddy/budget_buddy_api/category/CategoryIntegrationTest.java
@@ -311,6 +311,15 @@ class CategoryIntegrationTest extends BaseMvcIntegrationTest {
     }
 
     @Test
+    void should_Return400_When_PageSizeExceedsMaximum() {
+      var result = mvc.get().uri("/v1/categories?page=0&size=501")
+          .with(jwtForUser(userId))
+          .exchange();
+
+      assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
     void should_Return401_When_NotAuthenticated() {
       var result = mvc.get().uri("/v1/categories")
           .exchange();

--- a/src/main/java/com/budget/buddy/budget_buddy_api/base/crudl/base/BaseEntityController.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/base/crudl/base/BaseEntityController.java
@@ -17,6 +17,8 @@ import org.springframework.http.ResponseEntity;
  */
 public abstract class BaseEntityController<ID, R, C, U, L> {
 
+  private static final int MAX_PAGE_SIZE = 500;
+
   private final BaseEntityService<ID, R, C, U> service;
   private final BaseEntityMapper<?, R, C, U, L> mapper;
 
@@ -95,6 +97,9 @@ public abstract class BaseEntityController<ID, R, C, U, L> {
    * @return {@link ResponseEntity} with the paginated response
    */
   public ResponseEntity<L> listInternal(Integer page, Integer size) {
+    if (size > MAX_PAGE_SIZE) {
+      throw new IllegalArgumentException("Page size must not exceed " + MAX_PAGE_SIZE);
+    }
     return listInternal(PageRequest.of(page, size));
   }
 


### PR DESCRIPTION
## Summary

Adds a `MAX_PAGE_SIZE = 500` guard in `BaseEntityController.listInternal(Integer, Integer)`. Requests with `size > 500` are rejected with `400 Bad Request` via the existing `GlobalExceptionHandler` → `IllegalArgumentException` mapping.

Prevents a client from issuing unbounded queries that could cause OOM or act as a DoS vector.

## Test plan

- [ ] New test `should_Return400_When_PageSizeExceedsMaximum` added to `CategoryIntegrationTest`
- [ ] `GET /v1/categories?page=0&size=501` → `400`
- [ ] `GET /v1/categories?page=0&size=500` → `200` (boundary is inclusive)

Closes #82