### PR TITLE
ci: add Gitleaks secret scanning and OWASP dependency vulnerability scan

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Scan for secrets
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up JDK 25
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
@@ -49,10 +56,22 @@ jobs:
         with:
           cache-provider: basic
 
+      - name: Cache OWASP NVD data
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/dependency-check-data
+          key: owasp-nvd-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: owasp-nvd-${{ runner.os }}-
+
       - name: Build and test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew build
+
+      - name: OWASP dependency vulnerability scan
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew dependencyCheckAnalyze
 
       - name: Upload build artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,10 +4,19 @@ plugins {
   jacoco
   id("org.springframework.boot") version "4.0.5"
   id("io.spring.dependency-management") version "1.1.7"
+  id("org.owasp.dependencycheck") version "10.0.4"
 }
 
 group = "com.budget.buddy"
 description = "API for Budget Buddy App"
+
+dependencyCheck {
+  failBuildOnCVSS = 7.0f
+  suppressionFile = "dependency-check-suppressions.xml"
+  nvd {
+    apiKey = System.getenv("NVD_API_KEY") ?: ""
+  }
+}
 
 java {
   toolchain {

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+  <!--
+    Add suppression entries here for known-accepted CVEs.
+    Format:
+      <suppress>
+        <notes>Reason this CVE is accepted / why it doesn't apply</notes>
+        <cve>CVE-YYYY-XXXXX</cve>
+      </suppress>
+  -->
+</suppressions>


### PR DESCRIPTION
## Summary

- **#81** — Add `gitleaks/gitleaks-action@v2` step to the `ci` job (runs before the build, scans the full PR diff for leaked secrets). `fetch-depth: 0` added to checkout to ensure full history is available.
- **#83** — Add `org.owasp.dependencycheck` Gradle plugin (`failBuildOnCVSS = 7.0f`) and a `dependencyCheckAnalyze` CI step. NVD data is cached under `~/.gradle/dependency-check-data` to speed up subsequent runs. Empty `dependency-check-suppressions.xml` scaffolded for documenting accepted CVEs.

## Notes

- OWASP first run downloads ~200MB of NVD data — cached between runs via `actions/cache`. Cache key includes `run_id` so it refreshes daily.
- `NVD_API_KEY` env var is optional but highly recommended to avoid NVD rate-limiting (add as repo secret). Without it, downloads fall back to the legacy feed which is slower.
- Gitleaks action tag `@v2` — consider pinning to a commit SHA following the repo's convention once merged.
- OWASP plugin version `10.0.4` — check for a newer release before merging.

## Test plan

- [ ] CI workflow passes on a PR with no secrets and no vulnerable deps
- [ ] Introduce a test secret string → Gitleaks step should fail
- [ ] `dependencyCheckAnalyze` completes and produces a report in `build/reports/dependency-check-report.html`

Closes #81
Closes #83