### PR TITLE
feat: add correlation ID (X-Request-ID) to all responses and error logs

### DIFF
--- a/src/integrationTest/java/com/budget/buddy/budget_buddy_api/base/RequestIdFilterIntegrationTest.java
+++ b/src/integrationTest/java/com/budget/buddy/budget_buddy_api/base/RequestIdFilterIntegrationTest.java
@@ -1,0 +1,39 @@
+package com.budget.buddy.budget_buddy_api.base;
+
+import com.budget.buddy.budget_buddy_api.BaseMvcIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RequestIdFilterIntegrationTest extends BaseMvcIntegrationTest {
+
+  @Test
+  void should_ReturnRequestId_When_NotProvided() {
+    var result = mvc.get().uri("/v1/categories")
+        .with(jwtForUser(createTestUser()))
+        .exchange();
+
+    assertThat(result.getResponse().getHeader(RequestIdFilter.HEADER)).isNotBlank();
+  }
+
+  @Test
+  void should_EchoRequestId_When_ProvidedByClient() {
+    var clientId = "my-trace-id-123";
+
+    var result = mvc.get().uri("/v1/categories")
+        .with(jwtForUser(createTestUser()))
+        .header(RequestIdFilter.HEADER, clientId)
+        .exchange();
+
+    assertThat(result.getResponse().getHeader(RequestIdFilter.HEADER)).isEqualTo(clientId);
+  }
+
+  @Test
+  void should_ReturnRequestId_On_ErrorResponse() {
+    var result = mvc.get().uri("/v1/categories?page=0&size=99999")
+        .with(jwtForUser(createTestUser()))
+        .exchange();
+
+    assertThat(result.getResponse().getHeader(RequestIdFilter.HEADER)).isNotBlank();
+  }
+}

--- a/src/main/java/com/budget/buddy/budget_buddy_api/base/RequestIdFilter.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/base/RequestIdFilter.java
@@ -1,0 +1,42 @@
+package com.budget.buddy.budget_buddy_api.base;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class RequestIdFilter extends OncePerRequestFilter {
+
+  static final String HEADER = "X-Request-ID";
+  static final String MDC_KEY = "requestId";
+
+  @Override
+  protected void doFilterInternal(
+      @NonNull HttpServletRequest request,
+      @NonNull HttpServletResponse response,
+      @NonNull FilterChain chain
+  ) throws ServletException, IOException {
+    String requestId = request.getHeader(HEADER);
+    if (requestId == null || requestId.isBlank()) {
+      requestId = UUID.randomUUID().toString();
+    }
+    MDC.put(MDC_KEY, requestId);
+    response.setHeader(HEADER, requestId);
+    try {
+      chain.doFilter(request, response);
+    } finally {
+      MDC.remove(MDC_KEY);
+    }
+  }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -19,6 +19,10 @@ spring:
         maximumSize=200,
         expireAfterWrite=24h
 
+logging:
+  pattern:
+    console: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level [%X{requestId}] %logger{36} - %msg%n"
+
 server:
   port: ${SERVER_PORT:8080}
 


### PR DESCRIPTION
## Summary

Adds `RequestIdFilter` — a highest-priority `OncePerRequestFilter` that:

1. Reads `X-Request-ID` from the incoming request header (client-supplied trace ID) or generates a fresh UUID if absent
2. Stores it in MDC under key `requestId`
3. Echoes it back as `X-Request-ID` in **every** response, including error responses

When a client reports a `500`, they can provide the `X-Request-ID` value and you can `grep` the server logs by that exact ID.

Log pattern updated to include `[%X{requestId}]` so every log line emitted during a request carries the ID:

```
2026-04-22 12:00:00.000 [http-nio-8080-exec-1] ERROR [a1b2c3d4-...] c.b.b.b.GlobalExceptionHandler - Unhandled exception: ...
```

## Test plan

- [ ] `GET /v1/categories` → response contains `X-Request-ID` header
- [ ] `GET /v1/categories` with `X-Request-ID: my-id` → response echoes `X-Request-ID: my-id`
- [ ] `GET /v1/categories?size=99999` (triggers 400) → error response still contains `X-Request-ID`
- [ ] Server logs show `[<uuid>]` field for all request-scoped log lines

Closes #85