### PR TITLE
feat(security): trust X-Forwarded-* for DPoP URL validation behind proxy

### DIFF
--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -12,6 +12,9 @@ spring:
       idle-timeout: 300000
       max-lifetime: 1200000
 
+server:
+  forward-headers-strategy: framework
+
 management:
   endpoints:
     web:


### PR DESCRIPTION
## Summary

- Enable `server.forward-headers-strategy: framework` in the prod profile.
- Required so Spring reconstructs the external URL (`https://<host>/v1/...`) from `X-Forwarded-Proto` + `X-Forwarded-Host` / `Host` before validating the DPoP proof's `htu` claim. Without this, DPoP requests 401 because the client signed against the public URL and the API sees the internal `http://api:8080/...`.
- No Java code changes needed — Spring Security 7 auto-wires `DPoPAuthenticationConfigurer` via `spring-security-oauth2-jose` on the classpath. Bearer handling is unchanged.

Pairs with:
- `budget-buddy-deployment` PR: forward `X-Forwarded-Host` in `proxy.nginx.conf`.
- `budget-buddy-web-app` PR: enable DPoP in `oidc-client-ts` and attach proofs per request.

## Test plan

- [x] `./gradlew compileJava` passes
- [ ] `./gradlew check` (locally if Docker available)
- [ ] After deploy, sample a `/v1/*` request: with web app DPoP enabled, expect `Authorization: DPoP` + `DPoP: <proof>` → `200`. Without forward-headers flag, would be `401 invalid_dpop_proof`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)