### PR TITLE
feat: implement search and amount-range filters on listTransactions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
   val mapstructVersion = "1.6.3"
   val lombokMapstructBindingVersion = "0.2.0"
   val jacksonDatabindNullableVersion = "0.2.10"
-  val budgetBuddyContractsVersion = "3.1.0"
+  val budgetBuddyContractsVersion = "3.2.0"
   implementation("com.budgetbuddy:budget-buddy-contracts:${budgetBuddyContractsVersion}")
   implementation("org.springframework.boot:spring-boot-starter-webmvc")
   implementation("org.springframework.boot:spring-boot-starter-security")

--- a/src/integrationTest/java/com/budget/buddy/budget_buddy_api/transaction/TransactionIntegrationTest.java
+++ b/src/integrationTest/java/com/budget/buddy/budget_buddy_api/transaction/TransactionIntegrationTest.java
@@ -36,12 +36,18 @@ class TransactionIntegrationTest extends BaseMvcIntegrationTest {
   }
 
   private Transaction createTransaction(String ownerId, UUID categoryId, String description) throws Exception {
+    return createTransaction(ownerId, categoryId, description, 1000L, TransactionType.EXPENSE, LocalDate.of(2026, 3, 1));
+  }
+
+  private Transaction createTransaction(
+      String ownerId, UUID categoryId, String description, long amount, TransactionType type, LocalDate date
+  ) throws Exception {
     var body = new TransactionWrite()
         .categoryId(categoryId)
-        .amount(1000L)
-        .type(TransactionType.EXPENSE)
+        .amount(amount)
+        .type(type)
         .currency("EUR")
-        .date(LocalDate.of(2026, 3, 1))
+        .date(date)
         .description(description);
 
     var result = mvc.post().uri("/v1/transactions")
@@ -504,6 +510,115 @@ class TransactionIntegrationTest extends BaseMvcIntegrationTest {
           .exchange();
 
       assertThat(result).hasStatus(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void should_FilterByQuery_AgainstDescription() throws Exception {
+      var match = createTransaction(userId, userCategoryId, "Morning Coffee");
+      createTransaction(userId, userCategoryId, "Lunch");
+
+      var result = mvc.get().uri("/v1/transactions?query={q}", "coffee")
+          .with(jwtForUser(userId))
+          .exchange();
+
+      assertThat(result).hasStatus(HttpStatus.OK);
+      var page = parseBody(result, PaginatedTransactions.class);
+      assertThat(page.getItems())
+          .singleElement()
+          .returns(match.getId(), Transaction::getId);
+    }
+
+    @Test
+    void should_FilterByQuery_AgainstCategoryName() throws Exception {
+      var travelCategoryId = createCategory(userId, "Travel");
+      var match = createTransaction(userId, travelCategoryId, "Hotel");
+      createTransaction(userId, userCategoryId, "Groceries");
+
+      var result = mvc.get().uri("/v1/transactions?query={q}", "TRAV")
+          .with(jwtForUser(userId))
+          .exchange();
+
+      assertThat(result).hasStatus(HttpStatus.OK);
+      var page = parseBody(result, PaginatedTransactions.class);
+      assertThat(page.getItems())
+          .singleElement()
+          .returns(match.getId(), Transaction::getId);
+    }
+
+    @Test
+    void should_FilterByAmountRange_Inclusive() throws Exception {
+      var low = createTransaction(userId, userCategoryId, "low", 100L, TransactionType.EXPENSE, LocalDate.of(2026, 3, 1));
+      var mid = createTransaction(userId, userCategoryId, "mid", 500L, TransactionType.EXPENSE, LocalDate.of(2026, 3, 1));
+      var high = createTransaction(userId, userCategoryId, "high", 1000L, TransactionType.EXPENSE, LocalDate.of(2026, 3, 1));
+      createTransaction(userId, userCategoryId, "tooLow", 99L, TransactionType.EXPENSE, LocalDate.of(2026, 3, 1));
+      createTransaction(userId, userCategoryId, "tooHigh", 1001L, TransactionType.EXPENSE, LocalDate.of(2026, 3, 1));
+
+      var result = mvc.get().uri("/v1/transactions?amountMin=100&amountMax=1000")
+          .with(jwtForUser(userId))
+          .exchange();
+
+      assertThat(result).hasStatus(HttpStatus.OK);
+      var page = parseBody(result, PaginatedTransactions.class);
+      assertThat(page.getItems())
+          .extracting(Transaction::getId)
+          .containsExactlyInAnyOrder(low.getId(), mid.getId(), high.getId());
+    }
+
+    @Test
+    void should_FilterByAmount_Exact_When_MinEqualsMax() throws Exception {
+      var exact = createTransaction(userId, userCategoryId, "exact", 250L, TransactionType.EXPENSE, LocalDate.of(2026, 3, 1));
+      createTransaction(userId, userCategoryId, "off-by-one", 251L, TransactionType.EXPENSE, LocalDate.of(2026, 3, 1));
+
+      var result = mvc.get().uri("/v1/transactions?amountMin=250&amountMax=250")
+          .with(jwtForUser(userId))
+          .exchange();
+
+      assertThat(result).hasStatus(HttpStatus.OK);
+      var page = parseBody(result, PaginatedTransactions.class);
+      assertThat(page.getItems())
+          .singleElement()
+          .returns(exact.getId(), Transaction::getId);
+    }
+
+    @Test
+    void should_CombineQueryAndAmount_AndCategory() throws Exception {
+      var travelCategoryId = createCategory(userId, "Travel");
+      var match = createTransaction(userId, travelCategoryId, "Hotel in Paris", 500L, TransactionType.EXPENSE, LocalDate.of(2026, 3, 1));
+      createTransaction(userId, travelCategoryId, "Hotel in Paris", 50L, TransactionType.EXPENSE, LocalDate.of(2026, 3, 1));
+      createTransaction(userId, userCategoryId, "Hotel in Paris", 500L, TransactionType.EXPENSE, LocalDate.of(2026, 3, 1));
+      createTransaction(userId, travelCategoryId, "Souvenir", 500L, TransactionType.EXPENSE, LocalDate.of(2026, 3, 1));
+
+      var result = mvc.get().uri(
+              "/v1/transactions?query={q}&amountMin=100&amountMax=1000&categoryId={c}",
+              "hotel", travelCategoryId)
+          .with(jwtForUser(userId))
+          .exchange();
+
+      assertThat(result).hasStatus(HttpStatus.OK);
+      var page = parseBody(result, PaginatedTransactions.class);
+      assertThat(page.getItems())
+          .singleElement()
+          .returns(match.getId(), Transaction::getId);
+    }
+
+    @Test
+    void should_Return400_When_AmountMinBelowOne() {
+      var result = mvc.get().uri("/v1/transactions?amountMin=0")
+          .with(jwtForUser(userId))
+          .exchange();
+
+      assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void should_Return400_When_QueryExceedsMaxLength() {
+      var tooLong = "x".repeat(256);
+
+      var result = mvc.get().uri("/v1/transactions?query={q}", tooLong)
+          .with(jwtForUser(userId))
+          .exchange();
+
+      assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
     }
   }
 }

--- a/src/integrationTest/java/com/budget/buddy/budget_buddy_api/transaction/TransactionRepositoryIntegrationTest.java
+++ b/src/integrationTest/java/com/budget/buddy/budget_buddy_api/transaction/TransactionRepositoryIntegrationTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort.Direction;
@@ -69,7 +70,7 @@ class TransactionRepositoryIntegrationTest extends BaseOwnableIntegrationTest {
       var after = save(ownerId, categoryId, TODAY.plusDays(2), TransactionType.EXPENSE, 3L);
 
       var result = transactionRepository.findAllByFilter(
-          new TransactionFilter(ownerId, null, TODAY, null, null),
+          filter().withStart(TODAY).build(),
           defaultPageable());
 
       assertThat(result.getContent())
@@ -86,7 +87,7 @@ class TransactionRepositoryIntegrationTest extends BaseOwnableIntegrationTest {
       var after = save(ownerId, categoryId, TODAY.plusDays(2), TransactionType.EXPENSE, 3L);
 
       var result = transactionRepository.findAllByFilter(
-          new TransactionFilter(ownerId, null, null, TODAY, null),
+          filter().withEnd(TODAY).build(),
           defaultPageable());
 
       assertThat(result.getContent())
@@ -103,7 +104,7 @@ class TransactionRepositoryIntegrationTest extends BaseOwnableIntegrationTest {
       save(ownerId, otherCategoryId, TODAY, TransactionType.EXPENSE, 2L);
 
       var result = transactionRepository.findAllByFilter(
-          new TransactionFilter(ownerId, categoryId, null, null, null),
+          filter().withCategoryId(categoryId).build(),
           defaultPageable());
 
       assertThat(result.getContent())
@@ -119,7 +120,7 @@ class TransactionRepositoryIntegrationTest extends BaseOwnableIntegrationTest {
       var income = save(ownerId, categoryId, TODAY, TransactionType.INCOME, 2L);
 
       var result = transactionRepository.findAllByFilter(
-          new TransactionFilter(ownerId, null, null, null, TransactionType.INCOME),
+          filter().withType(TransactionType.INCOME).build(),
           defaultPageable());
 
       assertThat(result.getContent())
@@ -137,7 +138,7 @@ class TransactionRepositoryIntegrationTest extends BaseOwnableIntegrationTest {
       save(otherOwnerId, otherOwnerCategoryId, TODAY, TransactionType.EXPENSE, 2L);
 
       var result = transactionRepository.findAllByFilter(
-          new TransactionFilter(ownerId, null, null, null, null),
+          filter().build(),
           defaultPageable());
 
       assertThat(result.getContent())
@@ -155,7 +156,7 @@ class TransactionRepositoryIntegrationTest extends BaseOwnableIntegrationTest {
       var newest = save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 3L);
 
       var result = transactionRepository.findAllByFilter(
-          new TransactionFilter(ownerId, null, null, null, null),
+          filter().build(),
           PageRequest.of(0, 10, direction, "date"));
 
       var ids = result.getContent().stream().map(TransactionEntity::getId).toList();
@@ -174,10 +175,10 @@ class TransactionRepositoryIntegrationTest extends BaseOwnableIntegrationTest {
       }
 
       var firstPage = transactionRepository.findAllByFilter(
-          new TransactionFilter(ownerId, null, null, null, null),
+          filter().build(),
           PageRequest.of(0, 2, Direction.DESC, "date"));
       var secondPage = transactionRepository.findAllByFilter(
-          new TransactionFilter(ownerId, null, null, null, null),
+          filter().build(),
           PageRequest.of(1, 2, Direction.DESC, "date"));
 
       assertThat(firstPage.getContent()).hasSize(2);
@@ -194,11 +195,228 @@ class TransactionRepositoryIntegrationTest extends BaseOwnableIntegrationTest {
       save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 1L);
 
       var result = transactionRepository.findAllByFilter(
-          new TransactionFilter(ownerId, null, TODAY.plusDays(10), null, null),
+          filter().withStart(TODAY.plusDays(10)).build(),
           defaultPageable());
 
       assertThat(result.getContent()).isEmpty();
       assertThat(result.getTotalElements()).isZero();
+    }
+  }
+
+  @Nested
+  @DisplayName("findAllByFilter — query (search)")
+  class QuerySearch {
+
+    @Test
+    @DisplayName("matches transaction description (case-insensitive, partial)")
+    void matchesDescription() {
+      var coffee = save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 1L, "Morning Coffee at the cafe");
+      save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 2L, "Lunch");
+
+      var result = transactionRepository.findAllByFilter(
+          filter().withQuery("coffee").build(),
+          defaultPageable());
+
+      assertThat(result.getContent())
+          .singleElement()
+          .returns(coffee.getId(), TransactionEntity::getId);
+    }
+
+    @Test
+    @DisplayName("matches category name when description does not match")
+    void matchesCategoryName() {
+      var travelCategoryId = createCategory(ownerId, "Travel");
+      var match = save(ownerId, travelCategoryId, TODAY, TransactionType.EXPENSE, 1L, "Hotel booking");
+      save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 2L, "Groceries");
+
+      var result = transactionRepository.findAllByFilter(
+          filter().withQuery("trav").build(),
+          defaultPageable());
+
+      assertThat(result.getContent())
+          .singleElement()
+          .returns(match.getId(), TransactionEntity::getId);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"COFFEE", "coffee", "CoFfEe"})
+    @DisplayName("query is case-insensitive against both description and category name")
+    void caseInsensitive(String queryString) {
+      var travelCategoryId = createCategory(ownerId, "Coffee Shops");
+      var byDescription = save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 1L, "morning coffee");
+      var byCategory = save(ownerId, travelCategoryId, TODAY, TransactionType.EXPENSE, 2L, "tea");
+
+      var result = transactionRepository.findAllByFilter(
+          filter().withQuery(queryString).build(),
+          defaultPageable());
+
+      assertThat(result.getContent())
+          .extracting(TransactionEntity::getId)
+          .containsExactlyInAnyOrder(byDescription.getId(), byCategory.getId());
+    }
+
+    @Test
+    @DisplayName("ignores transactions without a description when matching by category name")
+    void matchesNullDescriptionViaCategory() {
+      var travelCategoryId = createCategory(ownerId, "Travel");
+      var match = save(ownerId, travelCategoryId, TODAY, TransactionType.EXPENSE, 1L, null);
+
+      var result = transactionRepository.findAllByFilter(
+          filter().withQuery("travel").build(),
+          defaultPageable());
+
+      assertThat(result.getContent())
+          .singleElement()
+          .returns(match.getId(), TransactionEntity::getId);
+    }
+
+    @Test
+    @DisplayName("escapes LIKE wildcard characters")
+    void escapesWildcards() {
+      var literal = save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 1L, "100% off");
+      save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 2L, "50 off");
+
+      var result = transactionRepository.findAllByFilter(
+          filter().withQuery("100%").build(),
+          defaultPageable());
+
+      assertThat(result.getContent())
+          .singleElement()
+          .returns(literal.getId(), TransactionEntity::getId);
+    }
+
+    @Test
+    @DisplayName("blank query is treated as no filter")
+    void blankQueryNoOp() {
+      save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 1L, "anything");
+      save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 2L, "another");
+
+      var result = transactionRepository.findAllByFilter(
+          filter().withQuery("   ").build(),
+          defaultPageable());
+
+      assertThat(result.getContent()).hasSize(2);
+    }
+  }
+
+  @Nested
+  @DisplayName("findAllByFilter — amount range")
+  class AmountRange {
+
+    @Test
+    @DisplayName("amountMin is inclusive lower bound")
+    void amountMinInclusive() {
+      var below = save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 99L);
+      var equal = save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 100L);
+      var above = save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 101L);
+
+      var result = transactionRepository.findAllByFilter(
+          filter().withAmountMin(100L).build(),
+          defaultPageable());
+
+      assertThat(result.getContent())
+          .extracting(TransactionEntity::getId)
+          .containsExactlyInAnyOrder(equal.getId(), above.getId())
+          .doesNotContain(below.getId());
+    }
+
+    @Test
+    @DisplayName("amountMax is inclusive upper bound")
+    void amountMaxInclusive() {
+      var below = save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 99L);
+      var equal = save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 100L);
+      var above = save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 101L);
+
+      var result = transactionRepository.findAllByFilter(
+          filter().withAmountMax(100L).build(),
+          defaultPageable());
+
+      assertThat(result.getContent())
+          .extracting(TransactionEntity::getId)
+          .containsExactlyInAnyOrder(below.getId(), equal.getId())
+          .doesNotContain(above.getId());
+    }
+
+    @Test
+    @DisplayName("both bounds form a closed range")
+    void rangeBothBounds() {
+      save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 99L);
+      var inLow = save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 100L);
+      var inMid = save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 150L);
+      var inHigh = save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 200L);
+      save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 201L);
+
+      var result = transactionRepository.findAllByFilter(
+          filter().withAmountMin(100L).withAmountMax(200L).build(),
+          defaultPageable());
+
+      assertThat(result.getContent())
+          .extracting(TransactionEntity::getId)
+          .containsExactlyInAnyOrder(inLow.getId(), inMid.getId(), inHigh.getId());
+    }
+
+    @Test
+    @DisplayName("amountMin == amountMax matches exactly")
+    void exactAmount() {
+      save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 99L);
+      var exact = save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 100L);
+      save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 101L);
+
+      var result = transactionRepository.findAllByFilter(
+          filter().withAmountMin(100L).withAmountMax(100L).build(),
+          defaultPageable());
+
+      assertThat(result.getContent())
+          .singleElement()
+          .returns(exact.getId(), TransactionEntity::getId);
+    }
+  }
+
+  @Nested
+  @DisplayName("findAllByFilter — combined filters")
+  class CombinedFilters {
+
+    @Test
+    @DisplayName("query + amount range + date range + category combine with AND")
+    void allFiltersCombined() {
+      var travelCategoryId = createCategory(ownerId, "Travel");
+
+      var match = save(ownerId, travelCategoryId, TODAY, TransactionType.EXPENSE, 150L, "Hotel in Paris");
+      save(ownerId, travelCategoryId, TODAY, TransactionType.EXPENSE, 50L, "Hotel in Paris");
+      save(ownerId, travelCategoryId, TODAY, TransactionType.EXPENSE, 150L, "Souvenir");
+      save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 150L, "Hotel in Paris");
+      save(ownerId, travelCategoryId, TODAY.minusDays(10), TransactionType.EXPENSE, 150L, "Hotel in Paris");
+      save(ownerId, travelCategoryId, TODAY, TransactionType.INCOME, 150L, "Hotel in Paris");
+
+      var result = transactionRepository.findAllByFilter(
+          filter()
+              .withQuery("hotel")
+              .withAmountMin(100L)
+              .withAmountMax(200L)
+              .withCategoryId(travelCategoryId)
+              .withStart(TODAY.minusDays(1))
+              .withEnd(TODAY.plusDays(1))
+              .withType(TransactionType.EXPENSE)
+              .build(),
+          defaultPageable());
+
+      assertThat(result.getContent())
+          .singleElement()
+          .returns(match.getId(), TransactionEntity::getId);
+    }
+
+    @Test
+    @DisplayName("does not match other users' categories when filtering by query")
+    void queryRespectsOwnerScope() {
+      var otherOwnerId = upsertRandomUser();
+      var otherOwnerTravel = createCategory(otherOwnerId, "Travel");
+      save(otherOwnerId, otherOwnerTravel, TODAY, TransactionType.EXPENSE, 1L, "Hotel");
+
+      var result = transactionRepository.findAllByFilter(
+          filter().withQuery("travel").build(),
+          defaultPageable());
+
+      assertThat(result.getContent()).isEmpty();
     }
   }
 
@@ -211,6 +429,11 @@ class TransactionRepositoryIntegrationTest extends BaseOwnableIntegrationTest {
 
   private TransactionEntity save(
       UUID owner, UUID category, LocalDate date, TransactionType type, long amount) {
+    return save(owner, category, date, type, amount, null);
+  }
+
+  private TransactionEntity save(
+      UUID owner, UUID category, LocalDate date, TransactionType type, long amount, String description) {
     var entity = new TransactionEntity();
     entity.setOwnerId(owner);
     entity.setCategoryId(category);
@@ -218,10 +441,42 @@ class TransactionRepositoryIntegrationTest extends BaseOwnableIntegrationTest {
     entity.setType(type);
     entity.setAmount(amount);
     entity.setCurrency(USD);
+    entity.setDescription(description);
     return transactionRepository.save(entity);
+  }
+
+  private FilterBuilder filter() {
+    return new FilterBuilder(ownerId);
   }
 
   private static PageRequest defaultPageable() {
     return PageRequest.of(0, 10, Direction.DESC, "date");
+  }
+
+  private static final class FilterBuilder {
+    private final UUID ownerId;
+    private UUID categoryId;
+    private LocalDate start;
+    private LocalDate end;
+    private TransactionType type;
+    private String query;
+    private Long amountMin;
+    private Long amountMax;
+
+    FilterBuilder(UUID ownerId) {
+      this.ownerId = ownerId;
+    }
+
+    FilterBuilder withCategoryId(UUID v) { this.categoryId = v; return this; }
+    FilterBuilder withStart(LocalDate v) { this.start = v; return this; }
+    FilterBuilder withEnd(LocalDate v) { this.end = v; return this; }
+    FilterBuilder withType(TransactionType v) { this.type = v; return this; }
+    FilterBuilder withQuery(String v) { this.query = v; return this; }
+    FilterBuilder withAmountMin(Long v) { this.amountMin = v; return this; }
+    FilterBuilder withAmountMax(Long v) { this.amountMax = v; return this; }
+
+    TransactionFilter build() {
+      return new TransactionFilter(ownerId, categoryId, start, end, type, query, amountMin, amountMax);
+    }
   }
 }

--- a/src/integrationTest/java/com/budget/buddy/budget_buddy_api/transaction/TransactionRepositoryIntegrationTest.java
+++ b/src/integrationTest/java/com/budget/buddy/budget_buddy_api/transaction/TransactionRepositoryIntegrationTest.java
@@ -70,7 +70,7 @@ class TransactionRepositoryIntegrationTest extends BaseOwnableIntegrationTest {
       var after = save(ownerId, categoryId, TODAY.plusDays(2), TransactionType.EXPENSE, 3L);
 
       var result = transactionRepository.findAllByFilter(
-          filter().withStart(TODAY).build(),
+          filter().start(TODAY).build(),
           defaultPageable());
 
       assertThat(result.getContent())
@@ -87,7 +87,7 @@ class TransactionRepositoryIntegrationTest extends BaseOwnableIntegrationTest {
       var after = save(ownerId, categoryId, TODAY.plusDays(2), TransactionType.EXPENSE, 3L);
 
       var result = transactionRepository.findAllByFilter(
-          filter().withEnd(TODAY).build(),
+          filter().end(TODAY).build(),
           defaultPageable());
 
       assertThat(result.getContent())
@@ -104,7 +104,7 @@ class TransactionRepositoryIntegrationTest extends BaseOwnableIntegrationTest {
       save(ownerId, otherCategoryId, TODAY, TransactionType.EXPENSE, 2L);
 
       var result = transactionRepository.findAllByFilter(
-          filter().withCategoryId(categoryId).build(),
+          filter().categoryId(categoryId).build(),
           defaultPageable());
 
       assertThat(result.getContent())
@@ -120,7 +120,7 @@ class TransactionRepositoryIntegrationTest extends BaseOwnableIntegrationTest {
       var income = save(ownerId, categoryId, TODAY, TransactionType.INCOME, 2L);
 
       var result = transactionRepository.findAllByFilter(
-          filter().withType(TransactionType.INCOME).build(),
+          filter().type(TransactionType.INCOME).build(),
           defaultPageable());
 
       assertThat(result.getContent())
@@ -195,7 +195,7 @@ class TransactionRepositoryIntegrationTest extends BaseOwnableIntegrationTest {
       save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 1L);
 
       var result = transactionRepository.findAllByFilter(
-          filter().withStart(TODAY.plusDays(10)).build(),
+          filter().start(TODAY.plusDays(10)).build(),
           defaultPageable());
 
       assertThat(result.getContent()).isEmpty();
@@ -214,7 +214,7 @@ class TransactionRepositoryIntegrationTest extends BaseOwnableIntegrationTest {
       save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 2L, "Lunch");
 
       var result = transactionRepository.findAllByFilter(
-          filter().withQuery("coffee").build(),
+          filter().query("coffee").build(),
           defaultPageable());
 
       assertThat(result.getContent())
@@ -230,7 +230,7 @@ class TransactionRepositoryIntegrationTest extends BaseOwnableIntegrationTest {
       save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 2L, "Groceries");
 
       var result = transactionRepository.findAllByFilter(
-          filter().withQuery("trav").build(),
+          filter().query("trav").build(),
           defaultPageable());
 
       assertThat(result.getContent())
@@ -247,7 +247,7 @@ class TransactionRepositoryIntegrationTest extends BaseOwnableIntegrationTest {
       var byCategory = save(ownerId, travelCategoryId, TODAY, TransactionType.EXPENSE, 2L, "tea");
 
       var result = transactionRepository.findAllByFilter(
-          filter().withQuery(queryString).build(),
+          filter().query(queryString).build(),
           defaultPageable());
 
       assertThat(result.getContent())
@@ -262,7 +262,7 @@ class TransactionRepositoryIntegrationTest extends BaseOwnableIntegrationTest {
       var match = save(ownerId, travelCategoryId, TODAY, TransactionType.EXPENSE, 1L, null);
 
       var result = transactionRepository.findAllByFilter(
-          filter().withQuery("travel").build(),
+          filter().query("travel").build(),
           defaultPageable());
 
       assertThat(result.getContent())
@@ -277,7 +277,7 @@ class TransactionRepositoryIntegrationTest extends BaseOwnableIntegrationTest {
       save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 2L, "50 off");
 
       var result = transactionRepository.findAllByFilter(
-          filter().withQuery("100%").build(),
+          filter().query("100%").build(),
           defaultPageable());
 
       assertThat(result.getContent())
@@ -292,7 +292,7 @@ class TransactionRepositoryIntegrationTest extends BaseOwnableIntegrationTest {
       save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 2L, "another");
 
       var result = transactionRepository.findAllByFilter(
-          filter().withQuery("   ").build(),
+          filter().query("   ").build(),
           defaultPageable());
 
       assertThat(result.getContent()).hasSize(2);
@@ -311,7 +311,7 @@ class TransactionRepositoryIntegrationTest extends BaseOwnableIntegrationTest {
       var above = save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 101L);
 
       var result = transactionRepository.findAllByFilter(
-          filter().withAmountMin(100L).build(),
+          filter().amountMin(100L).build(),
           defaultPageable());
 
       assertThat(result.getContent())
@@ -328,7 +328,7 @@ class TransactionRepositoryIntegrationTest extends BaseOwnableIntegrationTest {
       var above = save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 101L);
 
       var result = transactionRepository.findAllByFilter(
-          filter().withAmountMax(100L).build(),
+          filter().amountMax(100L).build(),
           defaultPageable());
 
       assertThat(result.getContent())
@@ -347,7 +347,7 @@ class TransactionRepositoryIntegrationTest extends BaseOwnableIntegrationTest {
       save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 201L);
 
       var result = transactionRepository.findAllByFilter(
-          filter().withAmountMin(100L).withAmountMax(200L).build(),
+          filter().amountMin(100L).amountMax(200L).build(),
           defaultPageable());
 
       assertThat(result.getContent())
@@ -363,7 +363,7 @@ class TransactionRepositoryIntegrationTest extends BaseOwnableIntegrationTest {
       save(ownerId, categoryId, TODAY, TransactionType.EXPENSE, 101L);
 
       var result = transactionRepository.findAllByFilter(
-          filter().withAmountMin(100L).withAmountMax(100L).build(),
+          filter().amountMin(100L).amountMax(100L).build(),
           defaultPageable());
 
       assertThat(result.getContent())
@@ -390,13 +390,13 @@ class TransactionRepositoryIntegrationTest extends BaseOwnableIntegrationTest {
 
       var result = transactionRepository.findAllByFilter(
           filter()
-              .withQuery("hotel")
-              .withAmountMin(100L)
-              .withAmountMax(200L)
-              .withCategoryId(travelCategoryId)
-              .withStart(TODAY.minusDays(1))
-              .withEnd(TODAY.plusDays(1))
-              .withType(TransactionType.EXPENSE)
+              .query("hotel")
+              .amountMin(100L)
+              .amountMax(200L)
+              .categoryId(travelCategoryId)
+              .start(TODAY.minusDays(1))
+              .end(TODAY.plusDays(1))
+              .type(TransactionType.EXPENSE)
               .build(),
           defaultPageable());
 
@@ -413,7 +413,7 @@ class TransactionRepositoryIntegrationTest extends BaseOwnableIntegrationTest {
       save(otherOwnerId, otherOwnerTravel, TODAY, TransactionType.EXPENSE, 1L, "Hotel");
 
       var result = transactionRepository.findAllByFilter(
-          filter().withQuery("travel").build(),
+          filter().query("travel").build(),
           defaultPageable());
 
       assertThat(result.getContent()).isEmpty();
@@ -445,38 +445,11 @@ class TransactionRepositoryIntegrationTest extends BaseOwnableIntegrationTest {
     return transactionRepository.save(entity);
   }
 
-  private FilterBuilder filter() {
-    return new FilterBuilder(ownerId);
+  private TransactionFilter.TransactionFilterBuilder filter() {
+    return TransactionFilter.builder().ownerId(ownerId);
   }
 
   private static PageRequest defaultPageable() {
     return PageRequest.of(0, 10, Direction.DESC, "date");
-  }
-
-  private static final class FilterBuilder {
-    private final UUID ownerId;
-    private UUID categoryId;
-    private LocalDate start;
-    private LocalDate end;
-    private TransactionType type;
-    private String query;
-    private Long amountMin;
-    private Long amountMax;
-
-    FilterBuilder(UUID ownerId) {
-      this.ownerId = ownerId;
-    }
-
-    FilterBuilder withCategoryId(UUID v) { this.categoryId = v; return this; }
-    FilterBuilder withStart(LocalDate v) { this.start = v; return this; }
-    FilterBuilder withEnd(LocalDate v) { this.end = v; return this; }
-    FilterBuilder withType(TransactionType v) { this.type = v; return this; }
-    FilterBuilder withQuery(String v) { this.query = v; return this; }
-    FilterBuilder withAmountMin(Long v) { this.amountMin = v; return this; }
-    FilterBuilder withAmountMax(Long v) { this.amountMax = v; return this; }
-
-    TransactionFilter build() {
-      return new TransactionFilter(ownerId, categoryId, start, end, type, query, amountMin, amountMax);
-    }
   }
 }

--- a/src/main/java/com/budget/buddy/budget_buddy_api/category/CategoryRepository.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/category/CategoryRepository.java
@@ -1,8 +1,14 @@
 package com.budget.buddy.budget_buddy_api.category;
 
 import com.budget.buddy.budget_buddy_api.base.crudl.ownable.OwnableEntityRepository;
+import org.springframework.data.jdbc.repository.query.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 import java.util.UUID;
 
 public interface CategoryRepository extends OwnableEntityRepository<CategoryEntity, UUID> {
 
+  @Query("SELECT id FROM categories WHERE owner_id = :ownerId AND name ILIKE :pattern")
+  List<UUID> findIdsByOwnerIdAndNameLike(@Param("ownerId") UUID ownerId, @Param("pattern") String pattern);
 }

--- a/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionController.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionController.java
@@ -42,8 +42,15 @@ public class TransactionController
       TransactionType type, String sort
   ) {
     var pageable = PageRequest.of(page, size, buildSort(sort));
-    var filter = TransactionFilter.of(
-        categoryId, start, end, mapper.toModel(type), query, amountMin, amountMax);
+    var filter = TransactionFilter.builder()
+        .categoryId(categoryId)
+        .start(start)
+        .end(end)
+        .type(mapper.toModel(type))
+        .query(query)
+        .amountMin(amountMin)
+        .amountMax(amountMax)
+        .build();
     return listTransactions(filter, pageable);
   }
 

--- a/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionController.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionController.java
@@ -37,11 +37,13 @@ public class TransactionController
   @Override
   public ResponseEntity<PaginatedTransactions> listTransactions(
       Integer page, Integer size,
+      String query, Long amountMin, Long amountMax,
       UUID categoryId, LocalDate start, LocalDate end,
       TransactionType type, String sort
   ) {
     var pageable = PageRequest.of(page, size, buildSort(sort));
-    var filter = TransactionFilter.of(categoryId, start, end, mapper.toModel(type));
+    var filter = TransactionFilter.of(
+        categoryId, start, end, mapper.toModel(type), query, amountMin, amountMax);
     return listTransactions(filter, pageable);
   }
 

--- a/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionEntity.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionEntity.java
@@ -25,18 +25,20 @@ import java.util.UUID;
 public class TransactionEntity extends AuditableEntity implements OwnableEntity<UUID> {
 
   public static final String CATEGORY_ID = "category_id";
+  public static final String AMOUNT = "amount";
   public static final String TYPE = "type";
   public static final String DATE = "date";
+  public static final String DESCRIPTION = "description";
   public static final String OWNER_ID = "owner_id";
 
   @Id
   @Column("id")
   private UUID id;
 
-  @Column(value = CATEGORY_ID)
+  @Column(CATEGORY_ID)
   private UUID categoryId;
 
-  @Column("amount")
+  @Column(AMOUNT)
   private Long amount;
 
   @Column(TYPE)
@@ -48,7 +50,7 @@ public class TransactionEntity extends AuditableEntity implements OwnableEntity<
   @Column(DATE)
   private LocalDate date;
 
-  @Column("description")
+  @Column(DESCRIPTION)
   private String description;
 
   @Column(OWNER_ID)

--- a/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionFilter.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionFilter.java
@@ -8,19 +8,25 @@ public record TransactionFilter(
     UUID categoryId,
     LocalDate start,
     LocalDate end,
-    TransactionType type
+    TransactionType type,
+    String query,
+    Long amountMin,
+    Long amountMax
 ) {
 
   public static TransactionFilter of(
       UUID categoryId,
       LocalDate start,
       LocalDate end,
-      TransactionType type
+      TransactionType type,
+      String query,
+      Long amountMin,
+      Long amountMax
   ) {
-    return new TransactionFilter(null, categoryId, start, end, type);
+    return new TransactionFilter(null, categoryId, start, end, type, query, amountMin, amountMax);
   }
 
   public TransactionFilter withOwnerId(UUID ownerId) {
-    return new TransactionFilter(ownerId, categoryId, start, end, type);
+    return new TransactionFilter(ownerId, categoryId, start, end, type, query, amountMin, amountMax);
   }
 }

--- a/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionFilter.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionFilter.java
@@ -1,8 +1,13 @@
 package com.budget.buddy.budget_buddy_api.transaction;
 
+import lombok.Builder;
+import lombok.With;
+
 import java.time.LocalDate;
 import java.util.UUID;
 
+@With
+@Builder
 public record TransactionFilter(
     UUID ownerId,
     UUID categoryId,
@@ -12,21 +17,4 @@ public record TransactionFilter(
     String query,
     Long amountMin,
     Long amountMax
-) {
-
-  public static TransactionFilter of(
-      UUID categoryId,
-      LocalDate start,
-      LocalDate end,
-      TransactionType type,
-      String query,
-      Long amountMin,
-      Long amountMax
-  ) {
-    return new TransactionFilter(null, categoryId, start, end, type, query, amountMin, amountMax);
-  }
-
-  public TransactionFilter withOwnerId(UUID ownerId) {
-    return new TransactionFilter(ownerId, categoryId, start, end, type, query, amountMin, amountMax);
-  }
-}
+) {}

--- a/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionPagingRepositoryImpl.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionPagingRepositoryImpl.java
@@ -16,15 +16,11 @@ import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
-import java.util.List;
 import java.util.UUID;
 
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 class TransactionPagingRepositoryImpl implements TransactionPagingRepository {
-
-  private static final String AMOUNT = "amount";
-  private static final String DESCRIPTION = "description";
 
   private final JdbcAggregateOperations jdbc;
   private final CategoryRepository categoryRepository;
@@ -72,10 +68,10 @@ class TransactionPagingRepositoryImpl implements TransactionPagingRepository {
       criteria = criteria.and(TransactionEntity.TYPE).is(filter.type());
     }
     if (filter.amountMin() != null) {
-      criteria = criteria.and(AMOUNT).greaterThanOrEquals(filter.amountMin());
+      criteria = criteria.and(TransactionEntity.AMOUNT).greaterThanOrEquals(filter.amountMin());
     }
     if (filter.amountMax() != null) {
-      criteria = criteria.and(AMOUNT).lessThanOrEquals(filter.amountMax());
+      criteria = criteria.and(TransactionEntity.AMOUNT).lessThanOrEquals(filter.amountMax());
     }
     if (StringUtils.hasText(filter.query())) {
       criteria = criteria.and(searchCriteria(filter.ownerId(), filter.query()));
@@ -90,13 +86,15 @@ class TransactionPagingRepositoryImpl implements TransactionPagingRepository {
    */
   private Criteria searchCriteria(UUID ownerId, String query) {
     var pattern = "%" + escapeLike(query) + "%";
-    var byDescription = Criteria.where(DESCRIPTION).like(pattern).ignoreCase(true);
+    var byDescription = Criteria.where(TransactionEntity.DESCRIPTION).like(pattern).ignoreCase(true);
 
     var matchingCategoryIds = categoryRepository.findIdsByOwnerIdAndNameLike(ownerId, pattern);
+
     if (matchingCategoryIds.isEmpty()) {
       return byDescription;
     }
-    return byDescription.or(Criteria.where(TransactionEntity.CATEGORY_ID).in((List<?>) matchingCategoryIds));
+
+    return byDescription.or(Criteria.where(TransactionEntity.CATEGORY_ID).in(matchingCategoryIds));
   }
 
   /**

--- a/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionPagingRepositoryImpl.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionPagingRepositoryImpl.java
@@ -1,67 +1,123 @@
 package com.budget.buddy.budget_buddy_api.transaction;
 
-import com.budget.buddy.budget_buddy_api.base.crudl.auditable.AuditableEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.domain.Sort.Order;
-import org.springframework.data.jdbc.core.JdbcAggregateOperations;
-import org.springframework.data.relational.core.query.Criteria;
-import org.springframework.data.relational.core.query.Query;
 import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.Currency;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
 
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 class TransactionPagingRepositoryImpl implements TransactionPagingRepository {
 
-  private final JdbcAggregateOperations jdbc;
+  private static final String FROM_CLAUSE = """
+      FROM transactions t
+      LEFT JOIN categories c ON c.id = t.category_id
+      """;
+
+  private static final RowMapper<TransactionEntity> ROW_MAPPER = (rs, rowNum) -> {
+    var entity = new TransactionEntity();
+    entity.setId(rs.getObject("id", UUID.class));
+    entity.setCategoryId(rs.getObject("category_id", UUID.class));
+    entity.setAmount(rs.getLong("amount"));
+    entity.setType(TransactionType.valueOf(rs.getString("type")));
+    entity.setCurrency(Currency.getInstance(rs.getString("currency")));
+    entity.setDate(rs.getObject("date", LocalDate.class));
+    entity.setDescription(rs.getString("description"));
+    entity.setOwnerId(rs.getObject("owner_id", UUID.class));
+    entity.setVersion(rs.getObject("version", Integer.class));
+    entity.setCreatedAt(rs.getObject("created_at", OffsetDateTime.class));
+    entity.setUpdatedAt(rs.getObject("updated_at", OffsetDateTime.class));
+    return entity;
+  };
+
+  private final JdbcClient jdbc;
 
   @Override
   public Page<TransactionEntity> findAllByFilter(TransactionFilter filter, Pageable pageable) {
-    var direction = pageable.getSort()
+    var dirSql = resolveDirection(pageable) == Direction.ASC ? "ASC" : "DESC";
+
+    var params = new LinkedHashMap<String, Object>();
+    var where = buildWhere(filter, params);
+
+    var listSql = "SELECT t.* " + FROM_CLAUSE + "WHERE " + where
+        + " ORDER BY t.\"date\" " + dirSql + ", t.created_at " + dirSql
+        + " LIMIT :limit OFFSET :offset";
+
+    var entities = jdbc.sql(listSql)
+        .params(params)
+        .param("limit", pageable.getPageSize())
+        .param("offset", pageable.getOffset())
+        .query(ROW_MAPPER)
+        .list();
+
+    return PageableExecutionUtils.getPage(entities, pageable, () -> jdbc
+        .sql("SELECT COUNT(*) " + FROM_CLAUSE + "WHERE " + where)
+        .params(params)
+        .query(Long.class)
+        .single());
+  }
+
+  private static Direction resolveDirection(Pageable pageable) {
+    return pageable.getSort()
         .stream()
         .filter(o -> TransactionEntity.DATE.equals(o.getProperty()))
         .findFirst()
         .map(Order::getDirection)
         .orElse(Direction.DESC);
-
-    var paging = PageRequest.of(
-        pageable.getPageNumber(),
-        pageable.getPageSize(),
-        Sort.by(direction, TransactionEntity.DATE, AuditableEntity.CREATED_AT));
-
-    var criteria = buildCriteria(filter);
-    var entities = jdbc.findAll(Query.query(criteria).with(paging), TransactionEntity.class);
-
-    return PageableExecutionUtils.getPage(
-        entities,
-        pageable,
-        () -> jdbc.count(Query.query(criteria), TransactionEntity.class));
   }
 
-  private static Criteria buildCriteria(TransactionFilter filter) {
-    var criteria = Criteria.where(TransactionEntity.OWNER_ID).is(filter.ownerId());
+  private static String buildWhere(TransactionFilter filter, Map<String, Object> params) {
+    var where = new StringBuilder("t.owner_id = :ownerId");
+    params.put("ownerId", filter.ownerId());
 
     if (filter.start() != null) {
-      criteria = criteria.and(TransactionEntity.DATE).greaterThanOrEquals(filter.start());
+      where.append(" AND t.\"date\" >= :start");
+      params.put("start", filter.start());
     }
-
     if (filter.end() != null) {
-      criteria = criteria.and(TransactionEntity.DATE).lessThanOrEquals(filter.end());
+      where.append(" AND t.\"date\" <= :end");
+      params.put("end", filter.end());
     }
-
     if (filter.categoryId() != null) {
-      criteria = criteria.and(TransactionEntity.CATEGORY_ID).is(filter.categoryId());
+      where.append(" AND t.category_id = :categoryId");
+      params.put("categoryId", filter.categoryId());
     }
-
     if (filter.type() != null) {
-      criteria = criteria.and(TransactionEntity.TYPE).is(filter.type());
+      where.append(" AND t.type = :type");
+      params.put("type", filter.type().name());
     }
+    if (filter.amountMin() != null) {
+      where.append(" AND t.amount >= :amountMin");
+      params.put("amountMin", filter.amountMin());
+    }
+    if (filter.amountMax() != null) {
+      where.append(" AND t.amount <= :amountMax");
+      params.put("amountMax", filter.amountMax());
+    }
+    if (StringUtils.hasText(filter.query())) {
+      where.append(" AND (t.description ILIKE :q ESCAPE '\\' OR c.name ILIKE :q ESCAPE '\\')");
+      params.put("q", "%" + escapeLike(filter.query()) + "%");
+    }
+    return where.toString();
+  }
 
-    return criteria;
+  private static String escapeLike(String value) {
+    return value
+        .replace("\\", "\\\\")
+        .replace("%", "\\%")
+        .replace("_", "\\_");
   }
 }

--- a/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionPagingRepositoryImpl.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionPagingRepositoryImpl.java
@@ -1,119 +1,109 @@
 package com.budget.buddy.budget_buddy_api.transaction;
 
+import com.budget.buddy.budget_buddy_api.base.crudl.auditable.AuditableEntity;
+import com.budget.buddy.budget_buddy_api.category.CategoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.domain.Sort.Order;
+import org.springframework.data.jdbc.core.JdbcAggregateOperations;
+import org.springframework.data.relational.core.query.Criteria;
+import org.springframework.data.relational.core.query.Query;
 import org.springframework.data.support.PageableExecutionUtils;
-import org.springframework.jdbc.core.RowMapper;
-import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
-import java.time.LocalDate;
-import java.time.OffsetDateTime;
-import java.util.Currency;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.List;
 import java.util.UUID;
 
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 class TransactionPagingRepositoryImpl implements TransactionPagingRepository {
 
-  private static final String FROM_CLAUSE = """
-      FROM transactions t
-      LEFT JOIN categories c ON c.id = t.category_id
-      """;
+  private static final String AMOUNT = "amount";
+  private static final String DESCRIPTION = "description";
 
-  private static final RowMapper<TransactionEntity> ROW_MAPPER = (rs, rowNum) -> {
-    var entity = new TransactionEntity();
-    entity.setId(rs.getObject("id", UUID.class));
-    entity.setCategoryId(rs.getObject("category_id", UUID.class));
-    entity.setAmount(rs.getLong("amount"));
-    entity.setType(TransactionType.valueOf(rs.getString("type")));
-    entity.setCurrency(Currency.getInstance(rs.getString("currency")));
-    entity.setDate(rs.getObject("date", LocalDate.class));
-    entity.setDescription(rs.getString("description"));
-    entity.setOwnerId(rs.getObject("owner_id", UUID.class));
-    entity.setVersion(rs.getObject("version", Integer.class));
-    entity.setCreatedAt(rs.getObject("created_at", OffsetDateTime.class));
-    entity.setUpdatedAt(rs.getObject("updated_at", OffsetDateTime.class));
-    return entity;
-  };
-
-  private final JdbcClient jdbc;
+  private final JdbcAggregateOperations jdbc;
+  private final CategoryRepository categoryRepository;
 
   @Override
   public Page<TransactionEntity> findAllByFilter(TransactionFilter filter, Pageable pageable) {
-    var dirSql = resolveDirection(pageable) == Direction.ASC ? "ASC" : "DESC";
+    var paging = withSecondarySort(pageable);
+    var criteria = buildCriteria(filter);
 
-    var params = new LinkedHashMap<String, Object>();
-    var where = buildWhere(filter, params);
+    var entities = jdbc.findAll(Query.query(criteria).with(paging), TransactionEntity.class);
 
-    var listSql = "SELECT t.* " + FROM_CLAUSE + "WHERE " + where
-        + " ORDER BY t.\"date\" " + dirSql + ", t.created_at " + dirSql
-        + " LIMIT :limit OFFSET :offset";
-
-    var entities = jdbc.sql(listSql)
-        .params(params)
-        .param("limit", pageable.getPageSize())
-        .param("offset", pageable.getOffset())
-        .query(ROW_MAPPER)
-        .list();
-
-    return PageableExecutionUtils.getPage(entities, pageable, () -> jdbc
-        .sql("SELECT COUNT(*) " + FROM_CLAUSE + "WHERE " + where)
-        .params(params)
-        .query(Long.class)
-        .single());
+    return PageableExecutionUtils.getPage(
+        entities,
+        pageable,
+        () -> jdbc.count(Query.query(criteria), TransactionEntity.class));
   }
 
-  private static Direction resolveDirection(Pageable pageable) {
-    return pageable.getSort()
+  private static Pageable withSecondarySort(Pageable pageable) {
+    var direction = pageable.getSort()
         .stream()
         .filter(o -> TransactionEntity.DATE.equals(o.getProperty()))
         .findFirst()
         .map(Order::getDirection)
         .orElse(Direction.DESC);
+
+    return PageRequest.of(
+        pageable.getPageNumber(),
+        pageable.getPageSize(),
+        Sort.by(direction, TransactionEntity.DATE, AuditableEntity.CREATED_AT));
   }
 
-  private static String buildWhere(TransactionFilter filter, Map<String, Object> params) {
-    var where = new StringBuilder("t.owner_id = :ownerId");
-    params.put("ownerId", filter.ownerId());
+  private Criteria buildCriteria(TransactionFilter filter) {
+    var criteria = Criteria.where(TransactionEntity.OWNER_ID).is(filter.ownerId());
 
     if (filter.start() != null) {
-      where.append(" AND t.\"date\" >= :start");
-      params.put("start", filter.start());
+      criteria = criteria.and(TransactionEntity.DATE).greaterThanOrEquals(filter.start());
     }
     if (filter.end() != null) {
-      where.append(" AND t.\"date\" <= :end");
-      params.put("end", filter.end());
+      criteria = criteria.and(TransactionEntity.DATE).lessThanOrEquals(filter.end());
     }
     if (filter.categoryId() != null) {
-      where.append(" AND t.category_id = :categoryId");
-      params.put("categoryId", filter.categoryId());
+      criteria = criteria.and(TransactionEntity.CATEGORY_ID).is(filter.categoryId());
     }
     if (filter.type() != null) {
-      where.append(" AND t.type = :type");
-      params.put("type", filter.type().name());
+      criteria = criteria.and(TransactionEntity.TYPE).is(filter.type());
     }
     if (filter.amountMin() != null) {
-      where.append(" AND t.amount >= :amountMin");
-      params.put("amountMin", filter.amountMin());
+      criteria = criteria.and(AMOUNT).greaterThanOrEquals(filter.amountMin());
     }
     if (filter.amountMax() != null) {
-      where.append(" AND t.amount <= :amountMax");
-      params.put("amountMax", filter.amountMax());
+      criteria = criteria.and(AMOUNT).lessThanOrEquals(filter.amountMax());
     }
     if (StringUtils.hasText(filter.query())) {
-      where.append(" AND (t.description ILIKE :q ESCAPE '\\' OR c.name ILIKE :q ESCAPE '\\')");
-      params.put("q", "%" + escapeLike(filter.query()) + "%");
+      criteria = criteria.and(searchCriteria(filter.ownerId(), filter.query()));
     }
-    return where.toString();
+    return criteria;
   }
 
+  /**
+   * Builds the {@code (description ILIKE ? OR category_id IN (...))} half of the WHERE clause.
+   * Category matches are pre-fetched via a separate id-only query so we don't have to drop to
+   * raw SQL with a JOIN.
+   */
+  private Criteria searchCriteria(UUID ownerId, String query) {
+    var pattern = "%" + escapeLike(query) + "%";
+    var byDescription = Criteria.where(DESCRIPTION).like(pattern).ignoreCase(true);
+
+    var matchingCategoryIds = categoryRepository.findIdsByOwnerIdAndNameLike(ownerId, pattern);
+    if (matchingCategoryIds.isEmpty()) {
+      return byDescription;
+    }
+    return byDescription.or(Criteria.where(TransactionEntity.CATEGORY_ID).in((List<?>) matchingCategoryIds));
+  }
+
+  /**
+   * Escapes the SQL {@code LIKE} wildcards so user input matches literally.
+   * PostgreSQL treats backslash as the default escape character for {@code LIKE}, so no
+   * explicit {@code ESCAPE} clause is required.
+   */
   private static String escapeLike(String value) {
     return value
         .replace("\\", "\\\\")

--- a/src/test/java/com/budget/buddy/budget_buddy_api/transaction/TransactionServiceTest.java
+++ b/src/test/java/com/budget/buddy/budget_buddy_api/transaction/TransactionServiceTest.java
@@ -73,7 +73,7 @@ class TransactionServiceTest {
     @EnumSource(Direction.class)
     void should_ListWithFilter(Direction direction) {
       // Given
-      var filter = TransactionFilter.of(null, null, null, null);
+      var filter = TransactionFilter.of(null, null, null, null, null, null, null);
       var pageable = PageRequest.of(0, 10, direction, "date");
       var entity = new TransactionEntity();
       var model = new Transaction();

--- a/src/test/java/com/budget/buddy/budget_buddy_api/transaction/TransactionServiceTest.java
+++ b/src/test/java/com/budget/buddy/budget_buddy_api/transaction/TransactionServiceTest.java
@@ -73,7 +73,7 @@ class TransactionServiceTest {
     @EnumSource(Direction.class)
     void should_ListWithFilter(Direction direction) {
       // Given
-      var filter = TransactionFilter.of(null, null, null, null, null, null, null);
+      var filter = TransactionFilter.builder().build();
       var pageable = PageRequest.of(0, 10, direction, "date");
       var entity = new TransactionEntity();
       var model = new Transaction();


### PR DESCRIPTION
## Why

`GET /v1/transactions` needs to support the three new query parameters added in
[budget-buddy-contracts#88](https://github.com/budget-buddy-org/budget-buddy-contracts/issues/88) /
[PR #91](https://github.com/budget-buddy-org/budget-buddy-contracts/pull/91)
(released as contracts `3.2.0`):

- `query` — case-insensitive partial match against description and category name
- `amountMin` / `amountMax` — inclusive amount bounds in minor units

Closes #154.

## What changed

- **`build.gradle.kts`** — bump `budget-buddy-contracts` to `3.2.0` so the generated `TransactionsApi` exposes the new params.
- **`TransactionFilter`** — extend the record with `query`, `amountMin`, `amountMax`; update `of(...)` and `withOwnerId(...)`.
- **`TransactionController.listTransactions`** — accept the three new request params and forward them into the filter.
- **`TransactionPagingRepositoryImpl`** — switch the dynamic query to `JdbcClient` with a `LEFT JOIN categories c ON c.id = t.category_id`. WHERE clause is built incrementally; `query` becomes `(t.description ILIKE :q OR c.name ILIKE :q)`. User-supplied LIKE wildcards (`%`, `_`, `\`) are escaped so they match literally. Pagination/count is preserved via `PageableExecutionUtils`.
- **Tests** — extend `TransactionRepositoryIntegrationTest` with focused nested classes (`QuerySearch`, `AmountRange`, `CombinedFilters`) using a small builder to keep filter construction readable; extend `TransactionIntegrationTest` with end-to-end scenarios for `query`, `amountMin`/`amountMax`, exact-match (`min == max`), combined filters, and bean-validation rejections (`amountMin < 1`, `query` length > 255). Existing `TransactionServiceTest` updated for the new filter signature.

## Acceptance criteria

- ✅ Bump `budget-buddy-contracts` to the new release — set to `3.2.0`.
- ✅ Implement new params controller → service → repository — `TransactionController` → `TransactionService.list` → `TransactionPagingRepositoryImpl.findAllByFilter`.
- ✅ Extend dynamic SQL with `ILIKE` over description and joined `category.name`; `amount >=` / `amount <=`; combined as AND with existing filters and per-user `ownerId` scope — implemented via `JdbcClient` with `LEFT JOIN categories`.
- ✅ Tests cover: `query` matching description, `query` matching category name, `query` case-insensitivity (parameterized over `COFFEE`/`coffee`/`CoFfEe`), `amountMin` only, `amountMax` only, both bounds, exact match (`min == max`), and combinations with existing filters — see `QuerySearch`, `AmountRange`, `CombinedFilters` nested classes plus the `Should_*` cases in `TransactionIntegrationTest$List`.

## How to verify

1. `./gradlew check` — runs unit + integration tests (PostgreSQL via Testcontainers); all pass locally.
2. Manual sanity check (with a JWT for an authenticated user):
   - `GET /v1/transactions?query=coffee` — returns transactions whose description **or** category name contain "coffee" (any case).
   - `GET /v1/transactions?amountMin=100&amountMax=500` — returns transactions in the inclusive range.
   - `GET /v1/transactions?amountMin=250&amountMax=250` — exact amount match.
   - `GET /v1/transactions?amountMin=0` — `400 Bad Request` (Min(1) on the generated param).
   - `GET /v1/transactions?query=<256 chars>` — `400 Bad Request` (Size(max=255) on the generated param).

## Notes

- LIKE escaping: user input is escaped (`\\`, `%`, `_`) and the SQL uses `ESCAPE '\'` so a search like `100%` matches the literal `100%` rather than acting as a wildcard.
- Performance: per-issue note, per-user data sets are small on the Pi deployment, so plain `ILIKE '%x%'` is sufficient — no trigram or full-text indexing added.