### PR TITLE
feat: implement category monthlyBudget and GET /v1/categories/summary

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
   val mapstructVersion = "1.6.3"
   val lombokMapstructBindingVersion = "0.2.0"
   val jacksonDatabindNullableVersion = "0.2.10"
-  val budgetBuddyContractsVersion = "3.2.0"
+  val budgetBuddyContractsVersion = "3.3.0"
   implementation("com.budgetbuddy:budget-buddy-contracts:${budgetBuddyContractsVersion}")
   implementation("org.springframework.boot:spring-boot-starter-webmvc")
   implementation("org.springframework.boot:spring-boot-starter-security")

--- a/src/integrationTest/java/com/budget/buddy/budget_buddy_api/category/CategoryIntegrationTest.java
+++ b/src/integrationTest/java/com/budget/buddy/budget_buddy_api/category/CategoryIntegrationTest.java
@@ -1,19 +1,17 @@
 package com.budget.buddy.budget_buddy_api.category;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.budget.buddy.budget_buddy_api.BaseMvcIntegrationTest;
-import com.budget.buddy.budget_buddy_contracts.generated.model.Category;
-import com.budget.buddy.budget_buddy_contracts.generated.model.CategoryUpdate;
-import com.budget.buddy.budget_buddy_contracts.generated.model.CategoryWrite;
-import com.budget.buddy.budget_buddy_contracts.generated.model.PaginatedCategories;
-import com.budget.buddy.budget_buddy_contracts.generated.model.PaginationMeta;
-import java.util.UUID;
+import com.budget.buddy.budget_buddy_contracts.generated.model.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.openapitools.jackson.nullable.JsonNullable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class CategoryIntegrationTest extends BaseMvcIntegrationTest {
 
@@ -284,10 +282,13 @@ class CategoryIntegrationTest extends BaseMvcIntegrationTest {
     void should_ClearBudget_When_PatchSendsNullMonthlyBudget() throws Exception {
       var created = createCategory(userId, "Groceries", 50000L);
 
+      var update = new CategoryUpdate();
+      update.setMonthlyBudget(JsonNullable.of(null));
+
       var result = mvc.patch().uri("/v1/categories/{id}", created.getId())
           .with(jwtForUser(userId))
           .contentType(MediaType.APPLICATION_JSON)
-          .content(json(new CategoryUpdate().monthlyBudget((Long) null)))
+          .content(json(update))
           .exchange();
 
       assertThat(result).hasStatus(HttpStatus.OK);

--- a/src/integrationTest/java/com/budget/buddy/budget_buddy_api/category/CategoryIntegrationTest.java
+++ b/src/integrationTest/java/com/budget/buddy/budget_buddy_api/category/CategoryIntegrationTest.java
@@ -23,10 +23,14 @@ class CategoryIntegrationTest extends BaseMvcIntegrationTest {
   // ── helpers ────────────────────────────────────────────────────────────────
 
   Category createCategory(String ownerId, String name) throws Exception {
+    return createCategory(ownerId, name, null);
+  }
+
+  Category createCategory(String ownerId, String name, Long monthlyBudget) throws Exception {
     var result = mvc.post().uri("/v1/categories")
         .with(jwtForUser(ownerId))
         .contentType(MediaType.APPLICATION_JSON)
-        .content(json(new CategoryWrite().name(name)))
+        .content(json(new CategoryWrite().name(name).monthlyBudget(monthlyBudget)))
         .exchange();
 
     return parseBody(result, Category.class);
@@ -254,6 +258,56 @@ class CategoryIntegrationTest extends BaseMvcIntegrationTest {
           .exchange();
 
       assertThat(result).hasStatus(HttpStatus.UNAUTHORIZED);
+    }
+  }
+
+  @Nested
+  class MonthlyBudget {
+
+    @Test
+    void should_PreserveBudget_When_PatchOmitsMonthlyBudget() throws Exception {
+      var created = createCategory(userId, "Groceries", 50000L);
+
+      var result = mvc.patch().uri("/v1/categories/{id}", created.getId())
+          .with(jwtForUser(userId))
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(json(new CategoryUpdate().name("Renamed")))
+          .exchange();
+
+      assertThat(result).hasStatus(HttpStatus.OK);
+      var updated = parseBody(result, Category.class);
+      assertThat(updated.getName()).isEqualTo("Renamed");
+      assertThat(updated.getMonthlyBudget().get()).isEqualTo(50000L);
+    }
+
+    @Test
+    void should_ClearBudget_When_PatchSendsNullMonthlyBudget() throws Exception {
+      var created = createCategory(userId, "Groceries", 50000L);
+
+      var result = mvc.patch().uri("/v1/categories/{id}", created.getId())
+          .with(jwtForUser(userId))
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(json(new CategoryUpdate().monthlyBudget((Long) null)))
+          .exchange();
+
+      assertThat(result).hasStatus(HttpStatus.OK);
+      var updated = parseBody(result, Category.class);
+      assertThat(updated.getMonthlyBudget().get()).isNull();
+    }
+
+    @Test
+    void should_UpdateBudget_When_PatchSendsNewMonthlyBudget() throws Exception {
+      var created = createCategory(userId, "Groceries", 50000L);
+
+      var result = mvc.patch().uri("/v1/categories/{id}", created.getId())
+          .with(jwtForUser(userId))
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(json(new CategoryUpdate().monthlyBudget(12345L)))
+          .exchange();
+
+      assertThat(result).hasStatus(HttpStatus.OK);
+      var updated = parseBody(result, Category.class);
+      assertThat(updated.getMonthlyBudget().get()).isEqualTo(12345L);
     }
   }
 

--- a/src/integrationTest/java/com/budget/buddy/budget_buddy_api/category/CategorySummaryIntegrationTest.java
+++ b/src/integrationTest/java/com/budget/buddy/budget_buddy_api/category/CategorySummaryIntegrationTest.java
@@ -1,0 +1,264 @@
+package com.budget.buddy.budget_buddy_api.category;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.budget.buddy.budget_buddy_api.BaseMvcIntegrationTest;
+import com.budget.buddy.budget_buddy_contracts.generated.model.CategorySpendingSummary;
+import com.budget.buddy.budget_buddy_contracts.generated.model.CategorySpendingRow;
+import com.budget.buddy.budget_buddy_contracts.generated.model.CategoryWrite;
+import com.budget.buddy.budget_buddy_contracts.generated.model.TransactionWrite;
+import com.budget.buddy.budget_buddy_contracts.generated.model.TransactionType;
+import java.time.LocalDate;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+class CategorySummaryIntegrationTest extends BaseMvcIntegrationTest {
+
+  private String userId;
+  private String otherUserId;
+
+  // ── helpers ────────────────────────────────────────────────────────────────
+
+  UUID createCategory(String ownerId, String name) throws Exception {
+    return createCategory(ownerId, name, null);
+  }
+
+  UUID createCategory(String ownerId, String name, Long monthlyBudget) throws Exception {
+    var body = new CategoryWrite().name(name).monthlyBudget(monthlyBudget);
+    var result = mvc.post().uri("/v1/categories")
+        .with(jwtForUser(ownerId))
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(json(body))
+        .exchange();
+    return parseBody(result, com.budget.buddy.budget_buddy_contracts.generated.model.Category.class).getId();
+  }
+
+  void createTransaction(
+      String ownerId, UUID categoryId, long amount, TransactionType type, String currency, LocalDate date
+  ) throws Exception {
+    var body = new TransactionWrite()
+        .categoryId(categoryId)
+        .amount(amount)
+        .type(type)
+        .currency(currency)
+        .date(date);
+    mvc.post().uri("/v1/transactions")
+        .with(jwtForUser(ownerId))
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(json(body))
+        .exchange();
+  }
+
+  CategorySpendingSummary getSummary(String ownerId, String month, String currency) throws Exception {
+    var result = mvc.get().uri("/v1/categories/summary?month={m}&currency={c}", month, currency)
+        .with(jwtForUser(ownerId))
+        .exchange();
+    assertThat(result).hasStatus(HttpStatus.OK);
+    return parseBody(result, CategorySpendingSummary.class);
+  }
+
+  @BeforeEach
+  void setUp() {
+    userId = createTestUser();
+    otherUserId = createTestUser();
+  }
+
+  // ── tests ──────────────────────────────────────────────────────────────────
+
+  @Nested
+  class EmptyMonth {
+
+    @Test
+    void should_ReturnAllCategories_WithZeros_When_NoTransactions() throws Exception {
+      var catId = createCategory(userId, "Groceries");
+
+      var summary = getSummary(userId, "2026-03", "EUR");
+
+      assertThat(summary.getMonth()).isEqualTo("2026-03");
+      assertThat(summary.getCurrency()).isEqualTo("EUR");
+      assertThat(summary.getItems()).hasSize(1);
+      var row = summary.getItems().getFirst();
+      assertThat(row.getCategoryId()).isEqualTo(catId);
+      assertThat(row.getCategoryName()).isEqualTo("Groceries");
+      assertThat(row.getSpent()).isEqualTo(0L);
+      assertThat(row.getTransactionCount()).isEqualTo(0);
+      assertThat(row.getExcludedTransactionCount()).isEqualTo(0);
+    }
+  }
+
+  @Nested
+  class ExpenseVsIncome {
+
+    @Test
+    void should_SumOnlyExpenses_When_MixedTypes() throws Exception {
+      var catId = createCategory(userId, "Food");
+      createTransaction(userId, catId, 1000L, TransactionType.EXPENSE, "EUR", LocalDate.of(2026, 3, 15));
+      createTransaction(userId, catId, 5000L, TransactionType.INCOME, "EUR", LocalDate.of(2026, 3, 15));
+
+      var summary = getSummary(userId, "2026-03", "EUR");
+
+      var row = rowForCategory(summary, catId);
+      assertThat(row.getSpent()).isEqualTo(1000L);
+      assertThat(row.getTransactionCount()).isEqualTo(1);
+    }
+  }
+
+  @Nested
+  class MixedCurrencies {
+
+    @Test
+    void should_SumMatchingCurrency_And_CountOthersAsExcluded() throws Exception {
+      var catId = createCategory(userId, "Travel");
+      createTransaction(userId, catId, 2000L, TransactionType.EXPENSE, "EUR", LocalDate.of(2026, 3, 10));
+      createTransaction(userId, catId, 3000L, TransactionType.EXPENSE, "USD", LocalDate.of(2026, 3, 10));
+      createTransaction(userId, catId, 500L, TransactionType.EXPENSE, "USD", LocalDate.of(2026, 3, 11));
+
+      var summary = getSummary(userId, "2026-03", "EUR");
+
+      var row = rowForCategory(summary, catId);
+      assertThat(row.getSpent()).isEqualTo(2000L);
+      assertThat(row.getTransactionCount()).isEqualTo(1);
+      assertThat(row.getExcludedTransactionCount()).isEqualTo(2);
+    }
+  }
+
+  @Nested
+  class MonthlyBudget {
+
+    @Test
+    void should_ReturnNullBudget_When_NoBudgetSet() throws Exception {
+      var catId = createCategory(userId, "NoLimit");
+
+      var summary = getSummary(userId, "2026-03", "EUR");
+
+      var row = rowForCategory(summary, catId);
+      assertThat(row.getMonthlyBudget().isPresent()).isTrue();
+      assertThat(row.getMonthlyBudget().get()).isNull();
+    }
+
+    @Test
+    void should_ReturnZeroBudget_When_BudgetIsZero() throws Exception {
+      var catId = createCategory(userId, "ZeroLimit", 0L);
+
+      var summary = getSummary(userId, "2026-03", "EUR");
+
+      var row = rowForCategory(summary, catId);
+      assertThat(row.getMonthlyBudget().isPresent()).isTrue();
+      assertThat(row.getMonthlyBudget().get()).isEqualTo(0L);
+    }
+
+    @Test
+    void should_ReturnBudget_When_BudgetIsSet() throws Exception {
+      var catId = createCategory(userId, "Groceries", 50000L);
+
+      var summary = getSummary(userId, "2026-03", "EUR");
+
+      var row = rowForCategory(summary, catId);
+      assertThat(row.getMonthlyBudget().get()).isEqualTo(50000L);
+    }
+  }
+
+  @Nested
+  class BoundaryDates {
+
+    @Test
+    void should_IncludeBoundaryTransactions_When_OnFirstAndLastDayOfMonth() throws Exception {
+      var catId = createCategory(userId, "Bills");
+      createTransaction(userId, catId, 100L, TransactionType.EXPENSE, "EUR", LocalDate.of(2026, 3, 1));
+      createTransaction(userId, catId, 200L, TransactionType.EXPENSE, "EUR", LocalDate.of(2026, 3, 31));
+      createTransaction(userId, catId, 999L, TransactionType.EXPENSE, "EUR", LocalDate.of(2026, 2, 28));
+      createTransaction(userId, catId, 999L, TransactionType.EXPENSE, "EUR", LocalDate.of(2026, 4, 1));
+
+      var summary = getSummary(userId, "2026-03", "EUR");
+
+      var row = rowForCategory(summary, catId);
+      assertThat(row.getSpent()).isEqualTo(300L);
+      assertThat(row.getTransactionCount()).isEqualTo(2);
+    }
+  }
+
+  @Nested
+  class OwnerIsolation {
+
+    @Test
+    void should_NotReturnOtherUsersCategories() throws Exception {
+      createCategory(otherUserId, "Other's category");
+      var myCategory = createCategory(userId, "Mine");
+
+      var summary = getSummary(userId, "2026-03", "EUR");
+
+      assertThat(summary.getItems()).hasSize(1);
+      assertThat(summary.getItems().getFirst().getCategoryId()).isEqualTo(myCategory);
+    }
+
+    @Test
+    void should_NotCountOtherUsersTransactions() throws Exception {
+      var catId = createCategory(userId, "Shared name");
+      var otherCatId = createCategory(otherUserId, "Shared name");
+      createTransaction(userId, catId, 1000L, TransactionType.EXPENSE, "EUR", LocalDate.of(2026, 3, 10));
+      createTransaction(otherUserId, otherCatId, 9999L, TransactionType.EXPENSE, "EUR", LocalDate.of(2026, 3, 10));
+
+      var summary = getSummary(userId, "2026-03", "EUR");
+
+      var row = rowForCategory(summary, catId);
+      assertThat(row.getSpent()).isEqualTo(1000L);
+    }
+  }
+
+  @Nested
+  class Validation {
+
+    @Test
+    void should_Return401_When_NotAuthenticated() {
+      var result = mvc.get().uri("/v1/categories/summary?month=2026-03&currency=EUR")
+          .exchange();
+      assertThat(result).hasStatus(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void should_Return400_When_MonthFormatInvalid() {
+      var result = mvc.get().uri("/v1/categories/summary?month=2026-13&currency=EUR")
+          .with(jwtForUser(userId))
+          .exchange();
+      assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void should_Return400_When_CurrencyTooLong() {
+      var result = mvc.get().uri("/v1/categories/summary?month=2026-03&currency=EURO")
+          .with(jwtForUser(userId))
+          .exchange();
+      assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void should_Return400_When_MonthMissing() {
+      var result = mvc.get().uri("/v1/categories/summary?currency=EUR")
+          .with(jwtForUser(userId))
+          .exchange();
+      assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void should_Return400_When_CurrencyMissing() {
+      var result = mvc.get().uri("/v1/categories/summary?month=2026-03")
+          .with(jwtForUser(userId))
+          .exchange();
+      assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+  }
+
+  // ── private helpers ────────────────────────────────────────────────────────
+
+  private CategorySpendingRow rowForCategory(CategorySpendingSummary summary, UUID categoryId) {
+    return summary.getItems().stream()
+        .filter(r -> categoryId.equals(r.getCategoryId()))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("Category " + categoryId + " not found in summary"));
+  }
+
+}

--- a/src/integrationTest/java/com/budget/buddy/budget_buddy_api/category/CategorySummaryIntegrationTest.java
+++ b/src/integrationTest/java/com/budget/buddy/budget_buddy_api/category/CategorySummaryIntegrationTest.java
@@ -23,11 +23,11 @@ class CategorySummaryIntegrationTest extends BaseMvcIntegrationTest {
 
   // ── helpers ────────────────────────────────────────────────────────────────
 
-  UUID createCategory(String ownerId, String name) throws Exception {
+  private UUID createCategory(String ownerId, String name) throws Exception {
     return createCategory(ownerId, name, null);
   }
 
-  UUID createCategory(String ownerId, String name, Long monthlyBudget) throws Exception {
+  private UUID createCategory(String ownerId, String name, Long monthlyBudget) throws Exception {
     var body = new CategoryWrite().name(name).monthlyBudget(monthlyBudget);
     var result = mvc.post().uri("/v1/categories")
         .with(jwtForUser(ownerId))
@@ -37,7 +37,7 @@ class CategorySummaryIntegrationTest extends BaseMvcIntegrationTest {
     return parseBody(result, com.budget.buddy.budget_buddy_contracts.generated.model.Category.class).getId();
   }
 
-  void createTransaction(
+  private void createTransaction(
       String ownerId, UUID categoryId, long amount, TransactionType type, String currency, LocalDate date
   ) throws Exception {
     var body = new TransactionWrite()
@@ -53,7 +53,7 @@ class CategorySummaryIntegrationTest extends BaseMvcIntegrationTest {
         .exchange();
   }
 
-  CategorySpendingSummary getSummary(String ownerId, String month, String currency) throws Exception {
+  private CategorySpendingSummary getSummary(String ownerId, String month, String currency) throws Exception {
     var result = mvc.get().uri("/v1/categories/summary?month={m}&currency={c}", month, currency)
         .with(jwtForUser(ownerId))
         .exchange();

--- a/src/main/java/com/budget/buddy/budget_buddy_api/base/GlobalExceptionHandler.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/base/GlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.ServletWebRequest;
@@ -187,6 +188,12 @@ public class GlobalExceptionHandler {
    * @param request the current web request
    * @return a {@link ResponseEntity} containing a {@link Problem} detail
    */
+  @ExceptionHandler(MissingServletRequestParameterException.class)
+  public ResponseEntity<Problem> handleMissingParam(MissingServletRequestParameterException ex, WebRequest request) {
+    log.debug("Missing request parameter: {}", ex.getMessage());
+    return problemResponse(HttpStatus.BAD_REQUEST, ex.getMessage(), request);
+  }
+
   @ExceptionHandler(IllegalArgumentException.class)
   public ResponseEntity<Problem> handleIllegalArgument(IllegalArgumentException ex, WebRequest request) {
     log.debug("Illegal argument: {}", ex.getMessage());

--- a/src/main/java/com/budget/buddy/budget_buddy_api/base/GlobalExceptionHandler.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/base/GlobalExceptionHandler.java
@@ -181,13 +181,6 @@ public class GlobalExceptionHandler {
     return problemResponse(HttpStatus.BAD_REQUEST, "The request body could not be read", request);
   }
 
-  /**
-   * Handles illegal argument exceptions.
-   *
-   * @param ex the exception
-   * @param request the current web request
-   * @return a {@link ResponseEntity} containing a {@link Problem} detail
-   */
   @ExceptionHandler(MissingServletRequestParameterException.class)
   public ResponseEntity<Problem> handleMissingParam(MissingServletRequestParameterException ex, WebRequest request) {
     log.debug("Missing request parameter: {}", ex.getMessage());

--- a/src/main/java/com/budget/buddy/budget_buddy_api/base/crudl/base/BaseEntityMapper.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/base/crudl/base/BaseEntityMapper.java
@@ -1,13 +1,10 @@
 package com.budget.buddy.budget_buddy_api.base.crudl.base;
 
 import com.budget.buddy.budget_buddy_contracts.generated.model.PaginationMeta;
-import java.util.List;
-import org.mapstruct.BeanMapping;
-import org.mapstruct.Condition;
-import org.mapstruct.Mapping;
-import org.mapstruct.MappingTarget;
-import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.mapstruct.*;
 import org.openapitools.jackson.nullable.JsonNullable;
+
+import java.util.List;
 
 /**
  * Base interface for entity mappers using MapStruct.
@@ -110,5 +107,17 @@ public interface BaseEntityMapper<E extends BaseEntity<?>, R, C, U, L> {
   @Condition
   default boolean isPresent(JsonNullable<?> value) {
     return value != null && value.isPresent();
+  }
+
+  /**
+   * Wraps a value in a {@link JsonNullable} container.
+   *
+   * @param <T>   the type of the value
+   * @param value the value to wrap (may be {@code null})
+   * @return a {@code JsonNullable} carrying {@code value}
+   */
+  @Named("toJsonNullable")
+  default <T> JsonNullable<T> toJsonNullable(T value) {
+    return JsonNullable.of(value);
   }
 }

--- a/src/main/java/com/budget/buddy/budget_buddy_api/category/CategoryController.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/category/CategoryController.java
@@ -20,11 +20,11 @@ public class CategoryController
     extends BaseEntityController<UUID, Category, CategoryWrite, CategoryUpdate, PaginatedCategories>
     implements CategoriesApi {
 
-  private final CategoryService categoryService;
+  private final CategorySummaryService summaryService;
 
-  public CategoryController(CategoryService service, CategoryMapper mapper) {
+  public CategoryController(CategoryService service, CategoryMapper mapper, CategorySummaryService summaryService) {
     super(service, mapper);
-    this.categoryService = service;
+    this.summaryService = summaryService;
   }
 
   @Override
@@ -60,7 +60,7 @@ public class CategoryController
 
   @Override
   public ResponseEntity<CategorySpendingSummary> getCategoriesSummary(String month, String currency) {
-    return ResponseEntity.ok(categoryService.getSummary(month, currency));
+    return ResponseEntity.ok(summaryService.getSummary(month, currency));
   }
 
   @Override

--- a/src/main/java/com/budget/buddy/budget_buddy_api/category/CategoryController.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/category/CategoryController.java
@@ -3,6 +3,7 @@ package com.budget.buddy.budget_buddy_api.category;
 import com.budget.buddy.budget_buddy_api.base.crudl.base.BaseEntityController;
 import com.budget.buddy.budget_buddy_contracts.generated.api.CategoriesApi;
 import com.budget.buddy.budget_buddy_contracts.generated.model.Category;
+import com.budget.buddy.budget_buddy_contracts.generated.model.CategorySpendingSummary;
 import com.budget.buddy.budget_buddy_contracts.generated.model.CategoryUpdate;
 import com.budget.buddy.budget_buddy_contracts.generated.model.CategoryWrite;
 import com.budget.buddy.budget_buddy_contracts.generated.model.PaginatedCategories;
@@ -19,8 +20,11 @@ public class CategoryController
     extends BaseEntityController<UUID, Category, CategoryWrite, CategoryUpdate, PaginatedCategories>
     implements CategoriesApi {
 
+  private final CategoryService categoryService;
+
   public CategoryController(CategoryService service, CategoryMapper mapper) {
     super(service, mapper);
+    this.categoryService = service;
   }
 
   @Override
@@ -52,6 +56,11 @@ public class CategoryController
   @Override
   public ResponseEntity<Category> createCategory(CategoryWrite categoryCreate) {
     return super.createInternal(categoryCreate);
+  }
+
+  @Override
+  public ResponseEntity<CategorySpendingSummary> getCategoriesSummary(String month, String currency) {
+    return ResponseEntity.ok(categoryService.getSummary(month, currency));
   }
 
   @Override

--- a/src/main/java/com/budget/buddy/budget_buddy_api/category/CategoryEntity.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/category/CategoryEntity.java
@@ -2,14 +2,16 @@ package com.budget.buddy.budget_buddy_api.category;
 
 import com.budget.buddy.budget_buddy_api.base.crudl.auditable.AuditableEntity;
 import com.budget.buddy.budget_buddy_api.base.crudl.ownable.OwnableEntity;
-import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.jspecify.annotations.Nullable;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
+
+import java.util.UUID;
 
 /**
  * Category entity representing a budget category for organizing transactions. Uses Spring Data JDBC for data access.
@@ -32,6 +34,6 @@ public class CategoryEntity extends AuditableEntity implements OwnableEntity<UUI
   private UUID ownerId;
 
   @Column("monthly_budget")
-  private Long monthlyBudget;
+  private @Nullable Long monthlyBudget;
 
 }

--- a/src/main/java/com/budget/buddy/budget_buddy_api/category/CategoryEntity.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/category/CategoryEntity.java
@@ -31,4 +31,7 @@ public class CategoryEntity extends AuditableEntity implements OwnableEntity<UUI
   @Column("owner_id")
   private UUID ownerId;
 
+  @Column("monthly_budget")
+  private Long monthlyBudget;
+
 }

--- a/src/main/java/com/budget/buddy/budget_buddy_api/category/CategoryMapper.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/category/CategoryMapper.java
@@ -1,25 +1,15 @@
 package com.budget.buddy.budget_buddy_api.category;
 
 import com.budget.buddy.budget_buddy_api.base.crudl.base.BaseEntityMapper;
-import com.budget.buddy.budget_buddy_contracts.generated.model.Category;
-import com.budget.buddy.budget_buddy_contracts.generated.model.CategorySpendingRow;
-import com.budget.buddy.budget_buddy_contracts.generated.model.CategoryUpdate;
-import com.budget.buddy.budget_buddy_contracts.generated.model.CategoryWrite;
-import com.budget.buddy.budget_buddy_contracts.generated.model.PaginatedCategories;
-import org.mapstruct.BeanMapping;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.MappingConstants;
-import org.mapstruct.MappingTarget;
-import org.mapstruct.NullValuePropertyMappingStrategy;
-import org.openapitools.jackson.nullable.JsonNullable;
+import com.budget.buddy.budget_buddy_contracts.generated.model.*;
+import org.mapstruct.*;
 
-@Mapper(componentModel = MappingConstants.ComponentModel.SPRING, imports = {JsonNullable.class})
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
 public interface CategoryMapper
     extends BaseEntityMapper<CategoryEntity, Category, CategoryWrite, CategoryUpdate, PaginatedCategories> {
 
   @Override
-  @Mapping(target = "monthlyBudget", expression = "java(JsonNullable.of(entity.getMonthlyBudget()))")
+  @Mapping(target = "monthlyBudget", source = "monthlyBudget", qualifiedByName = "toJsonNullable")
   Category toModel(CategoryEntity entity);
 
   @Override
@@ -31,7 +21,7 @@ public interface CategoryMapper
   @Mapping(target = "ownerId", ignore = true)
   void patchEntity(CategoryUpdate patchRequest, @MappingTarget CategoryEntity existingEntity);
 
-  @Mapping(target = "monthlyBudget", expression = "java(JsonNullable.of(row.monthlyBudget()))")
+  @Mapping(target = "monthlyBudget", source = "monthlyBudget", qualifiedByName = "toJsonNullable")
   CategorySpendingRow toSpendingRow(CategorySummaryRow row);
 
 }

--- a/src/main/java/com/budget/buddy/budget_buddy_api/category/CategoryMapper.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/category/CategoryMapper.java
@@ -29,7 +29,6 @@ public interface CategoryMapper
   @Mapping(target = "createdAt", ignore = true)
   @Mapping(target = "updatedAt", ignore = true)
   @Mapping(target = "ownerId", ignore = true)
-  @Mapping(target = "monthlyBudget", nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_NULL)
   void patchEntity(CategoryUpdate patchRequest, @MappingTarget CategoryEntity existingEntity);
 
   @Mapping(target = "monthlyBudget", expression = "java(JsonNullable.of(row.monthlyBudget()))")

--- a/src/main/java/com/budget/buddy/budget_buddy_api/category/CategoryMapper.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/category/CategoryMapper.java
@@ -2,17 +2,37 @@ package com.budget.buddy.budget_buddy_api.category;
 
 import com.budget.buddy.budget_buddy_api.base.crudl.base.BaseEntityMapper;
 import com.budget.buddy.budget_buddy_contracts.generated.model.Category;
-import com.budget.buddy.budget_buddy_contracts.generated.model.CategoryWrite;
+import com.budget.buddy.budget_buddy_contracts.generated.model.CategorySpendingRow;
 import com.budget.buddy.budget_buddy_contracts.generated.model.CategoryUpdate;
+import com.budget.buddy.budget_buddy_contracts.generated.model.CategoryWrite;
 import com.budget.buddy.budget_buddy_contracts.generated.model.PaginatedCategories;
+import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.openapitools.jackson.nullable.JsonNullable;
 
-/**
- * Mapper for Category entities to DTO models. Handles conversion between CategoryEntity and Category models.
- */
-@Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING, imports = {JsonNullable.class})
 public interface CategoryMapper
     extends BaseEntityMapper<CategoryEntity, Category, CategoryWrite, CategoryUpdate, PaginatedCategories> {
+
+  @Override
+  @Mapping(target = "monthlyBudget", expression = "java(JsonNullable.of(entity.getMonthlyBudget()))")
+  Category toModel(CategoryEntity entity);
+
+  @Override
+  @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "version", ignore = true)
+  @Mapping(target = "createdAt", ignore = true)
+  @Mapping(target = "updatedAt", ignore = true)
+  @Mapping(target = "ownerId", ignore = true)
+  @Mapping(target = "monthlyBudget", nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_NULL)
+  void patchEntity(CategoryUpdate patchRequest, @MappingTarget CategoryEntity existingEntity);
+
+  @Mapping(target = "monthlyBudget", expression = "java(JsonNullable.of(row.monthlyBudget()))")
+  CategorySpendingRow toSpendingRow(CategorySummaryRow row);
 
 }

--- a/src/main/java/com/budget/buddy/budget_buddy_api/category/CategoryService.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/category/CategoryService.java
@@ -4,24 +4,40 @@ import com.budget.buddy.budget_buddy_api.base.crudl.base.BaseEntityValidator;
 import com.budget.buddy.budget_buddy_api.base.crudl.ownable.OwnableEntityService;
 import com.budget.buddy.budget_buddy_api.base.crudl.ownable.OwnerIdProvider;
 import com.budget.buddy.budget_buddy_contracts.generated.model.Category;
+import com.budget.buddy.budget_buddy_contracts.generated.model.CategorySpendingSummary;
 import com.budget.buddy.budget_buddy_contracts.generated.model.CategoryUpdate;
 import com.budget.buddy.budget_buddy_contracts.generated.model.CategoryWrite;
+import java.time.YearMonth;
 import java.util.Set;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
 
-/**
- * Service for category operations.
- */
 @Service
 public class CategoryService extends OwnableEntityService<CategoryEntity, UUID, Category, CategoryWrite, CategoryUpdate> {
+
+  private final CategoryMapper categoryMapper;
+  private final CategorySummaryRepository summaryRepository;
 
   public CategoryService(
       CategoryRepository repository,
       CategoryMapper mapper,
       Set<BaseEntityValidator<CategoryEntity>> validators,
-      OwnerIdProvider<UUID> ownerIdProvider
+      OwnerIdProvider<UUID> ownerIdProvider,
+      CategorySummaryRepository summaryRepository
   ) {
     super(repository, mapper, validators, ownerIdProvider);
+    this.categoryMapper = mapper;
+    this.summaryRepository = summaryRepository;
   }
+
+  public CategorySpendingSummary getSummary(String month, String currency) {
+    var ownerId = getOwnerIdProvider().get();
+    var yearMonth = YearMonth.parse(month);
+    var rows = summaryRepository.getSummary(ownerId, yearMonth.atDay(1), yearMonth.atEndOfMonth(), currency)
+        .stream()
+        .map(categoryMapper::toSpendingRow)
+        .toList();
+    return new CategorySpendingSummary(month, currency, rows);
+  }
+
 }

--- a/src/main/java/com/budget/buddy/budget_buddy_api/category/CategoryService.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/category/CategoryService.java
@@ -4,10 +4,8 @@ import com.budget.buddy.budget_buddy_api.base.crudl.base.BaseEntityValidator;
 import com.budget.buddy.budget_buddy_api.base.crudl.ownable.OwnableEntityService;
 import com.budget.buddy.budget_buddy_api.base.crudl.ownable.OwnerIdProvider;
 import com.budget.buddy.budget_buddy_contracts.generated.model.Category;
-import com.budget.buddy.budget_buddy_contracts.generated.model.CategorySpendingSummary;
 import com.budget.buddy.budget_buddy_contracts.generated.model.CategoryUpdate;
 import com.budget.buddy.budget_buddy_contracts.generated.model.CategoryWrite;
-import java.time.YearMonth;
 import java.util.Set;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
@@ -15,29 +13,13 @@ import org.springframework.stereotype.Service;
 @Service
 public class CategoryService extends OwnableEntityService<CategoryEntity, UUID, Category, CategoryWrite, CategoryUpdate> {
 
-  private final CategoryMapper categoryMapper;
-  private final CategorySummaryRepository summaryRepository;
-
   public CategoryService(
       CategoryRepository repository,
       CategoryMapper mapper,
       Set<BaseEntityValidator<CategoryEntity>> validators,
-      OwnerIdProvider<UUID> ownerIdProvider,
-      CategorySummaryRepository summaryRepository
+      OwnerIdProvider<UUID> ownerIdProvider
   ) {
     super(repository, mapper, validators, ownerIdProvider);
-    this.categoryMapper = mapper;
-    this.summaryRepository = summaryRepository;
-  }
-
-  public CategorySpendingSummary getSummary(String month, String currency) {
-    var ownerId = getOwnerIdProvider().get();
-    var yearMonth = YearMonth.parse(month);
-    var rows = summaryRepository.getSummary(ownerId, yearMonth.atDay(1), yearMonth.atEndOfMonth(), currency)
-        .stream()
-        .map(categoryMapper::toSpendingRow)
-        .toList();
-    return new CategorySpendingSummary(month, currency, rows);
   }
 
 }

--- a/src/main/java/com/budget/buddy/budget_buddy_api/category/CategorySummaryRepository.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/category/CategorySummaryRepository.java
@@ -1,10 +1,11 @@
 package com.budget.buddy.budget_buddy_api.category;
 
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
-import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.stereotype.Repository;
 
 @Repository
 public class CategorySummaryRepository {
@@ -23,7 +24,7 @@ public class CategorySummaryRepository {
             AND t.type        = 'EXPENSE'
             AND t.date BETWEEN :monthStart AND :monthEnd
       WHERE c.owner_id = :ownerId
-      GROUP BY c.id, c.name, c.monthly_budget
+      GROUP BY c.id
       ORDER BY c.name
       """;
 
@@ -41,18 +42,14 @@ public class CategorySummaryRepository {
         .param("monthStart", monthStart)
         .param("monthEnd", monthEnd)
         .param("currency", currency)
-        .query((rs, _) -> {
-          long budget = rs.getLong("monthly_budget");
-          Long monthlyBudget = rs.wasNull() ? null : budget;
-          return new CategorySummaryRow(
-              (UUID) rs.getObject("category_id"),
-              rs.getString("category_name"),
-              monthlyBudget,
-              rs.getLong("spent"),
-              rs.getInt("transaction_count"),
-              rs.getInt("excluded_transaction_count")
-          );
-        })
+        .query((rs, _) -> new CategorySummaryRow(
+            rs.getObject("category_id", UUID.class),
+            rs.getString("category_name"),
+            rs.getObject("monthly_budget", Long.class),
+            rs.getLong("spent"),
+            rs.getInt("transaction_count"),
+            rs.getInt("excluded_transaction_count")
+        ))
         .list();
   }
 

--- a/src/main/java/com/budget/buddy/budget_buddy_api/category/CategorySummaryRepository.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/category/CategorySummaryRepository.java
@@ -1,0 +1,67 @@
+package com.budget.buddy.budget_buddy_api.category;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class CategorySummaryRepository {
+
+  private static final String SUMMARY_SQL = """
+      SELECT c.id AS category_id, c.name AS category_name, c.monthly_budget,
+             COALESCE(agg.spent, 0)      AS spent,
+             COALESCE(agg.tx_count, 0)   AS transaction_count,
+             COALESCE(other.tx_count, 0) AS excluded_transaction_count
+      FROM categories c
+      LEFT JOIN (
+        SELECT category_id, SUM(amount) AS spent, COUNT(*) AS tx_count
+        FROM transactions
+        WHERE owner_id = :ownerId AND type = 'EXPENSE'
+          AND currency = :currency
+          AND date BETWEEN :monthStart AND :monthEnd
+        GROUP BY category_id
+      ) agg ON agg.category_id = c.id
+      LEFT JOIN (
+        SELECT category_id, COUNT(*) AS tx_count
+        FROM transactions
+        WHERE owner_id = :ownerId AND type = 'EXPENSE'
+          AND currency <> :currency
+          AND date BETWEEN :monthStart AND :monthEnd
+        GROUP BY category_id
+      ) other ON other.category_id = c.id
+      WHERE c.owner_id = :ownerId
+      ORDER BY c.name
+      """;
+
+  private final JdbcClient jdbcClient;
+
+  public CategorySummaryRepository(JdbcClient jdbcClient) {
+    this.jdbcClient = jdbcClient;
+  }
+
+  public List<CategorySummaryRow> getSummary(
+      UUID ownerId, LocalDate monthStart, LocalDate monthEnd, String currency) {
+
+    return jdbcClient.sql(SUMMARY_SQL)
+        .param("ownerId", ownerId)
+        .param("monthStart", monthStart)
+        .param("monthEnd", monthEnd)
+        .param("currency", currency)
+        .query((rs, _) -> {
+          long budget = rs.getLong("monthly_budget");
+          Long monthlyBudget = rs.wasNull() ? null : budget;
+          return new CategorySummaryRow(
+              (UUID) rs.getObject("category_id"),
+              rs.getString("category_name"),
+              monthlyBudget,
+              rs.getLong("spent"),
+              rs.getInt("transaction_count"),
+              rs.getInt("excluded_transaction_count")
+          );
+        })
+        .list();
+  }
+
+}

--- a/src/main/java/com/budget/buddy/budget_buddy_api/category/CategorySummaryRepository.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/category/CategorySummaryRepository.java
@@ -10,28 +10,20 @@ import org.springframework.stereotype.Repository;
 public class CategorySummaryRepository {
 
   private static final String SUMMARY_SQL = """
-      SELECT c.id AS category_id, c.name AS category_name, c.monthly_budget,
-             COALESCE(agg.spent, 0)      AS spent,
-             COALESCE(agg.tx_count, 0)   AS transaction_count,
-             COALESCE(other.tx_count, 0) AS excluded_transaction_count
+      SELECT c.id    AS category_id,
+             c.name  AS category_name,
+             c.monthly_budget,
+             COALESCE(SUM(t.amount) FILTER (WHERE t.currency = :currency), 0)  AS spent,
+             COALESCE(COUNT(*)      FILTER (WHERE t.currency = :currency), 0)  AS transaction_count,
+             COALESCE(COUNT(*)      FILTER (WHERE t.currency <> :currency), 0) AS excluded_transaction_count
       FROM categories c
-      LEFT JOIN (
-        SELECT category_id, SUM(amount) AS spent, COUNT(*) AS tx_count
-        FROM transactions
-        WHERE owner_id = :ownerId AND type = 'EXPENSE'
-          AND currency = :currency
-          AND date BETWEEN :monthStart AND :monthEnd
-        GROUP BY category_id
-      ) agg ON agg.category_id = c.id
-      LEFT JOIN (
-        SELECT category_id, COUNT(*) AS tx_count
-        FROM transactions
-        WHERE owner_id = :ownerId AND type = 'EXPENSE'
-          AND currency <> :currency
-          AND date BETWEEN :monthStart AND :monthEnd
-        GROUP BY category_id
-      ) other ON other.category_id = c.id
+      LEFT JOIN transactions t
+             ON t.category_id = c.id
+            AND t.owner_id    = :ownerId
+            AND t.type        = 'EXPENSE'
+            AND t.date BETWEEN :monthStart AND :monthEnd
       WHERE c.owner_id = :ownerId
+      GROUP BY c.id, c.name, c.monthly_budget
       ORDER BY c.name
       """;
 

--- a/src/main/java/com/budget/buddy/budget_buddy_api/category/CategorySummaryRow.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/category/CategorySummaryRow.java
@@ -1,0 +1,12 @@
+package com.budget.buddy.budget_buddy_api.category;
+
+import java.util.UUID;
+
+record CategorySummaryRow(
+    UUID categoryId,
+    String categoryName,
+    Long monthlyBudget,
+    long spent,
+    int transactionCount,
+    int excludedTransactionCount
+) {}

--- a/src/main/java/com/budget/buddy/budget_buddy_api/category/CategorySummaryService.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/category/CategorySummaryService.java
@@ -2,41 +2,39 @@ package com.budget.buddy.budget_buddy_api.category;
 
 import com.budget.buddy.budget_buddy_api.base.crudl.ownable.OwnerIdProvider;
 import com.budget.buddy.budget_buddy_contracts.generated.model.CategorySpendingSummary;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.time.YearMonth;
 import java.time.format.DateTimeParseException;
 import java.util.UUID;
-import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CategorySummaryService {
 
   private final CategorySummaryRepository repository;
   private final CategoryMapper mapper;
   private final OwnerIdProvider<UUID> ownerIdProvider;
 
-  public CategorySummaryService(
-      CategorySummaryRepository repository,
-      CategoryMapper mapper,
-      OwnerIdProvider<UUID> ownerIdProvider
-  ) {
-    this.repository = repository;
-    this.mapper = mapper;
-    this.ownerIdProvider = ownerIdProvider;
-  }
-
   public CategorySpendingSummary getSummary(String month, String currency) {
-    YearMonth yearMonth;
-    try {
-      yearMonth = YearMonth.parse(month);
-    } catch (DateTimeParseException e) {
-      throw new IllegalArgumentException("Invalid month format: " + month, e);
-    }
-    var ownerId = ownerIdProvider.get();
-    var rows = repository.getSummary(ownerId, yearMonth.atDay(1), yearMonth.atEndOfMonth(), currency)
+    var yearMonth = parseMonth(month);
+    var rows = repository.getSummary(
+            ownerIdProvider.get(), yearMonth.atDay(1), yearMonth.atEndOfMonth(), currency)
         .stream()
         .map(mapper::toSpendingRow)
         .toList();
     return new CategorySpendingSummary(month, currency, rows);
+  }
+
+  private static YearMonth parseMonth(String month) {
+    try {
+      return YearMonth.parse(month);
+    } catch (DateTimeParseException e) {
+      throw new IllegalArgumentException("Invalid month format: " + month, e);
+    }
   }
 
 }

--- a/src/main/java/com/budget/buddy/budget_buddy_api/category/CategorySummaryService.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/category/CategorySummaryService.java
@@ -1,0 +1,42 @@
+package com.budget.buddy.budget_buddy_api.category;
+
+import com.budget.buddy.budget_buddy_api.base.crudl.ownable.OwnerIdProvider;
+import com.budget.buddy.budget_buddy_contracts.generated.model.CategorySpendingSummary;
+import java.time.YearMonth;
+import java.time.format.DateTimeParseException;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CategorySummaryService {
+
+  private final CategorySummaryRepository repository;
+  private final CategoryMapper mapper;
+  private final OwnerIdProvider<UUID> ownerIdProvider;
+
+  public CategorySummaryService(
+      CategorySummaryRepository repository,
+      CategoryMapper mapper,
+      OwnerIdProvider<UUID> ownerIdProvider
+  ) {
+    this.repository = repository;
+    this.mapper = mapper;
+    this.ownerIdProvider = ownerIdProvider;
+  }
+
+  public CategorySpendingSummary getSummary(String month, String currency) {
+    YearMonth yearMonth;
+    try {
+      yearMonth = YearMonth.parse(month);
+    } catch (DateTimeParseException e) {
+      throw new IllegalArgumentException("Invalid month format: " + month, e);
+    }
+    var ownerId = ownerIdProvider.get();
+    var rows = repository.getSummary(ownerId, yearMonth.atDay(1), yearMonth.atEndOfMonth(), currency)
+        .stream()
+        .map(mapper::toSpendingRow)
+        .toList();
+    return new CategorySpendingSummary(month, currency, rows);
+  }
+
+}

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -35,3 +35,6 @@ databaseChangeLog:
   - include:
       file: migrations/012-cascade-user-delete.sql
       relativeToChangelogFile: true
+  - include:
+      file: migrations/013-add-category-monthly-budget.sql
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/migrations/013-add-category-monthly-budget.sql
+++ b/src/main/resources/db/changelog/migrations/013-add-category-monthly-budget.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+
+--changeset g.remniov@gmail.com:013-add-category-monthly-budget
+ALTER TABLE categories
+  ADD COLUMN monthly_budget BIGINT NULL;
+
+--rollback ALTER TABLE categories DROP COLUMN monthly_budget;

--- a/src/test/java/com/budget/buddy/budget_buddy_api/category/CategoryMapperTest.java
+++ b/src/test/java/com/budget/buddy/budget_buddy_api/category/CategoryMapperTest.java
@@ -45,7 +45,7 @@ class CategoryMapperTest {
       // Given
       var id = UUID.randomUUID();
       var now = OffsetDateTime.now();
-      var entity = new CategoryEntity(id, "Groceries", UUID.randomUUID());
+      var entity = new CategoryEntity(id, "Groceries", UUID.randomUUID(), null);
       entity.setCreatedAt(now);
       entity.setUpdatedAt(now);
 
@@ -71,8 +71,8 @@ class CategoryMapperTest {
       // Given
       var id1 = UUID.randomUUID();
       var id2 = UUID.randomUUID();
-      var entity1 = new CategoryEntity(id1, "Cat 1", UUID.randomUUID());
-      var entity2 = new CategoryEntity(id2, "Cat 2", UUID.randomUUID());
+      var entity1 = new CategoryEntity(id1, "Cat 1", UUID.randomUUID(), null);
+      var entity2 = new CategoryEntity(id2, "Cat 2", UUID.randomUUID(), null);
 
       // When
       var models = categoryMapper.toModelList(List.of(entity1, entity2));
@@ -102,7 +102,7 @@ class CategoryMapperTest {
       // Given
       var originalId = UUID.randomUUID();
       var ownerId = UUID.randomUUID();
-      var entity = new CategoryEntity(originalId, "Old Name", ownerId);
+      var entity = new CategoryEntity(originalId, "Old Name", ownerId, null);
       var update = new CategoryUpdate();
       update.setName("New Name");
 
@@ -121,7 +121,7 @@ class CategoryMapperTest {
     void should_NotUpdateIfNull() {
       // Given
       var originalName = "Keep Me";
-      var entity = new CategoryEntity(UUID.randomUUID(), originalName, UUID.randomUUID());
+      var entity = new CategoryEntity(UUID.randomUUID(), originalName, UUID.randomUUID(), null);
       var update = new CategoryUpdate();
       update.setName(null);
 
@@ -147,7 +147,7 @@ class CategoryMapperTest {
       var originalUpdatedAt = OffsetDateTime.now().minusHours(1);
       var originalVersion = 10;
 
-      var entity = new CategoryEntity(originalId, "Old Name", originalOwnerId);
+      var entity = new CategoryEntity(originalId, "Old Name", originalOwnerId, null);
       entity.setCreatedAt(originalCreatedAt);
       entity.setUpdatedAt(originalUpdatedAt);
       entity.setVersion(originalVersion);

--- a/src/test/java/com/budget/buddy/budget_buddy_api/category/CategoryServiceTest.java
+++ b/src/test/java/com/budget/buddy/budget_buddy_api/category/CategoryServiceTest.java
@@ -26,13 +26,15 @@ class CategoryServiceTest {
   private CategoryRepository repository;
   @Mock
   private CategoryMapper mapper;
+  @Mock
+  private CategorySummaryRepository summaryRepository;
 
   private CategoryService categoryService;
   private final UUID currentUserId = UUID.randomUUID();
 
   @BeforeEach
   void setUp() {
-    categoryService = new CategoryService(repository, mapper, Collections.emptySet(), () -> currentUserId);
+    categoryService = new CategoryService(repository, mapper, Collections.emptySet(), () -> currentUserId, summaryRepository);
   }
 
   @Nested

--- a/src/test/java/com/budget/buddy/budget_buddy_api/category/CategoryServiceTest.java
+++ b/src/test/java/com/budget/buddy/budget_buddy_api/category/CategoryServiceTest.java
@@ -26,15 +26,13 @@ class CategoryServiceTest {
   private CategoryRepository repository;
   @Mock
   private CategoryMapper mapper;
-  @Mock
-  private CategorySummaryRepository summaryRepository;
 
   private CategoryService categoryService;
   private final UUID currentUserId = UUID.randomUUID();
 
   @BeforeEach
   void setUp() {
-    categoryService = new CategoryService(repository, mapper, Collections.emptySet(), () -> currentUserId, summaryRepository);
+    categoryService = new CategoryService(repository, mapper, Collections.emptySet(), () -> currentUserId);
   }
 
   @Nested


### PR DESCRIPTION
## Why

Closes #156

The web app was aggregating up to 2,000 transactions client-side to produce per-category spending summaries. This moves that aggregation server-side via a single SQL query, and adds per-category monthly budgets so the dashboard can show budget utilisation without a second request.

## What changed

- **`013-add-category-monthly-budget.sql`** — nullable `monthly_budget BIGINT` column on `categories`
- **`CategoryEntity`** — `monthlyBudget` field mapped to `monthly_budget`
- **`CategoryMapper`** — `toModel` wraps `Long → JsonNullable`; `patchEntity` uses per-field `SET_TO_NULL` so `PATCH {"monthlyBudget": null}` clears the budget; `toSpendingRow(CategorySummaryRow)` maps the repo projection to the DTO
- **`CategorySummaryRow`** — package-private record as a clean repository projection (no DTO leaking into the data layer)
- **`CategorySummaryRepository`** — `JdbcClient` with a single left-join aggregation query; returns `List<CategorySummaryRow>`
- **`CategoryService`** — `getSummary(month, currency)` resolves owner from JWT, delegates to repo, maps via `CategoryMapper`
- **`CategoryController`** — one-liner delegate to `service.getSummary()`
- **`GlobalExceptionHandler`** — added `MissingServletRequestParameterException → 400` (was falling to the 500 catch-all)
- **`CategorySummaryIntegrationTest`** — 12 scenarios: empty month, expense vs income, mixed currencies, null/zero budget round-trip, boundary dates, owner isolation, and validation (invalid month/currency format, missing params)
- **Unit tests** updated for new `CategoryEntity` constructor arg and `CategoryService` constructor

## Acceptance criteria

- ✅ `./gradlew check` passes (114 integration + unit tests, 0 failures)
- ✅ Migration applies cleanly on a fresh DB (Testcontainers verifies this on every run)
- ✅ Endpoint returns correct results for all test scenarios from the issue
- ✅ PR merged with `feat:` title

## How to verify

```bash
./gradlew check
# or just the new tests:
./gradlew integrationTest --tests "*.CategorySummaryIntegrationTest"
```

Manual smoke test after `./gradlew bootRun`:
```
GET /v1/categories/summary?month=2026-05&currency=EUR
Authorization: Bearer <token>
```