### PR TITLE
feat: implement GET /v1/transactions/summary

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
   val mapstructVersion = "1.6.3"
   val lombokMapstructBindingVersion = "0.2.0"
   val jacksonDatabindNullableVersion = "0.2.10"
-  val budgetBuddyContractsVersion = "3.3.0"
+  val budgetBuddyContractsVersion = "3.4.0"
   implementation("com.budgetbuddy:budget-buddy-contracts:${budgetBuddyContractsVersion}")
   implementation("org.springframework.boot:spring-boot-starter-webmvc")
   implementation("org.springframework.boot:spring-boot-starter-security")

--- a/src/integrationTest/java/com/budget/buddy/budget_buddy_api/transaction/TransactionSummaryIntegrationTest.java
+++ b/src/integrationTest/java/com/budget/buddy/budget_buddy_api/transaction/TransactionSummaryIntegrationTest.java
@@ -1,0 +1,208 @@
+package com.budget.buddy.budget_buddy_api.transaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.budget.buddy.budget_buddy_api.BaseMvcIntegrationTest;
+import com.budget.buddy.budget_buddy_contracts.generated.model.CategoryWrite;
+import com.budget.buddy.budget_buddy_contracts.generated.model.MonthlySummary;
+import com.budget.buddy.budget_buddy_contracts.generated.model.TransactionType;
+import com.budget.buddy.budget_buddy_contracts.generated.model.TransactionWrite;
+import java.time.LocalDate;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+class TransactionSummaryIntegrationTest extends BaseMvcIntegrationTest {
+
+  private String userId;
+  private String otherUserId;
+
+  // ── helpers ────────────────────────────────────────────────────────────────
+
+  private UUID createCategory(String ownerId, String name) throws Exception {
+    var body = new CategoryWrite().name(name).monthlyBudget(null);
+    var result = mvc.post().uri("/v1/categories")
+        .with(jwtForUser(ownerId))
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(json(body))
+        .exchange();
+    return parseBody(result, com.budget.buddy.budget_buddy_contracts.generated.model.Category.class).getId();
+  }
+
+  private void createTransaction(
+      String ownerId, UUID categoryId, long amount, TransactionType type, String currency, LocalDate date
+  ) throws Exception {
+    var body = new TransactionWrite()
+        .categoryId(categoryId)
+        .amount(amount)
+        .type(type)
+        .currency(currency)
+        .date(date);
+    mvc.post().uri("/v1/transactions")
+        .with(jwtForUser(ownerId))
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(json(body))
+        .exchange();
+  }
+
+  private MonthlySummary getSummary(String ownerId, String month, String currency) throws Exception {
+    var result = mvc.get().uri("/v1/transactions/summary?month={m}&currency={c}", month, currency)
+        .with(jwtForUser(ownerId))
+        .exchange();
+    assertThat(result).hasStatus(HttpStatus.OK);
+    return parseBody(result, MonthlySummary.class);
+  }
+
+  @BeforeEach
+  void setUp() {
+    userId = createTestUser();
+    otherUserId = createTestUser();
+  }
+
+  // ── tests ──────────────────────────────────────────────────────────────────
+
+  @Nested
+  class EmptyMonth {
+
+    @Test
+    void should_ReturnZeros_When_NoTransactions() throws Exception {
+      var summary = getSummary(userId, "2026-03", "EUR");
+
+      assertThat(summary.getMonth()).isEqualTo("2026-03");
+      assertThat(summary.getCurrency()).isEqualTo("EUR");
+      assertThat(summary.getIncome()).isEqualTo(0L);
+      assertThat(summary.getExpense()).isEqualTo(0L);
+      assertThat(summary.getBalance()).isEqualTo(0L);
+      assertThat(summary.getIncomeCount()).isEqualTo(0);
+      assertThat(summary.getExpenseCount()).isEqualTo(0);
+      assertThat(summary.getExcludedTransactionCount()).isEqualTo(0);
+    }
+  }
+
+  @Nested
+  class IncomeVsExpense {
+
+    @Test
+    void should_SumIncomeAndExpenseSeparately_AndComputeBalance() throws Exception {
+      var catId = createCategory(userId, "Misc");
+      createTransaction(userId, catId, 5000L, TransactionType.INCOME, "EUR", LocalDate.of(2026, 3, 5));
+      createTransaction(userId, catId, 2500L, TransactionType.INCOME, "EUR", LocalDate.of(2026, 3, 12));
+      createTransaction(userId, catId, 1000L, TransactionType.EXPENSE, "EUR", LocalDate.of(2026, 3, 15));
+
+      var summary = getSummary(userId, "2026-03", "EUR");
+
+      assertThat(summary.getIncome()).isEqualTo(7500L);
+      assertThat(summary.getExpense()).isEqualTo(1000L);
+      assertThat(summary.getBalance()).isEqualTo(6500L);
+      assertThat(summary.getIncomeCount()).isEqualTo(2);
+      assertThat(summary.getExpenseCount()).isEqualTo(1);
+      assertThat(summary.getExcludedTransactionCount()).isEqualTo(0);
+    }
+  }
+
+  @Nested
+  class MixedCurrencies {
+
+    @Test
+    void should_SumMatchingCurrency_And_CountOthersAsExcluded() throws Exception {
+      var catId = createCategory(userId, "Travel");
+      createTransaction(userId, catId, 2000L, TransactionType.EXPENSE, "EUR", LocalDate.of(2026, 3, 10));
+      createTransaction(userId, catId, 4000L, TransactionType.INCOME, "EUR", LocalDate.of(2026, 3, 11));
+      createTransaction(userId, catId, 3000L, TransactionType.EXPENSE, "USD", LocalDate.of(2026, 3, 10));
+      createTransaction(userId, catId, 500L, TransactionType.INCOME, "GBP", LocalDate.of(2026, 3, 11));
+
+      var summary = getSummary(userId, "2026-03", "EUR");
+
+      assertThat(summary.getIncome()).isEqualTo(4000L);
+      assertThat(summary.getExpense()).isEqualTo(2000L);
+      assertThat(summary.getBalance()).isEqualTo(2000L);
+      assertThat(summary.getIncomeCount()).isEqualTo(1);
+      assertThat(summary.getExpenseCount()).isEqualTo(1);
+      assertThat(summary.getExcludedTransactionCount()).isEqualTo(2);
+    }
+  }
+
+  @Nested
+  class BoundaryDates {
+
+    @Test
+    void should_IncludeBoundaryTransactions_When_OnFirstAndLastDayOfMonth() throws Exception {
+      var catId = createCategory(userId, "Bills");
+      createTransaction(userId, catId, 100L, TransactionType.EXPENSE, "EUR", LocalDate.of(2026, 3, 1));
+      createTransaction(userId, catId, 200L, TransactionType.EXPENSE, "EUR", LocalDate.of(2026, 3, 31));
+      createTransaction(userId, catId, 999L, TransactionType.EXPENSE, "EUR", LocalDate.of(2026, 2, 28));
+      createTransaction(userId, catId, 999L, TransactionType.EXPENSE, "EUR", LocalDate.of(2026, 4, 1));
+
+      var summary = getSummary(userId, "2026-03", "EUR");
+
+      assertThat(summary.getExpense()).isEqualTo(300L);
+      assertThat(summary.getExpenseCount()).isEqualTo(2);
+    }
+  }
+
+  @Nested
+  class OwnerIsolation {
+
+    @Test
+    void should_NotCountOtherUsersTransactions() throws Exception {
+      var myCat = createCategory(userId, "Mine");
+      var otherCat = createCategory(otherUserId, "Other");
+      createTransaction(userId, myCat, 1000L, TransactionType.EXPENSE, "EUR", LocalDate.of(2026, 3, 10));
+      createTransaction(otherUserId, otherCat, 9999L, TransactionType.EXPENSE, "EUR", LocalDate.of(2026, 3, 10));
+      createTransaction(otherUserId, otherCat, 8888L, TransactionType.INCOME, "EUR", LocalDate.of(2026, 3, 10));
+
+      var summary = getSummary(userId, "2026-03", "EUR");
+
+      assertThat(summary.getExpense()).isEqualTo(1000L);
+      assertThat(summary.getIncome()).isEqualTo(0L);
+      assertThat(summary.getExpenseCount()).isEqualTo(1);
+      assertThat(summary.getIncomeCount()).isEqualTo(0);
+    }
+  }
+
+  @Nested
+  class Validation {
+
+    @Test
+    void should_Return401_When_NotAuthenticated() {
+      var result = mvc.get().uri("/v1/transactions/summary?month=2026-03&currency=EUR").exchange();
+      assertThat(result).hasStatus(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void should_Return400_When_MonthFormatInvalid() {
+      var result = mvc.get().uri("/v1/transactions/summary?month=2026-13&currency=EUR")
+          .with(jwtForUser(userId))
+          .exchange();
+      assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void should_Return400_When_CurrencyTooLong() {
+      var result = mvc.get().uri("/v1/transactions/summary?month=2026-03&currency=EURO")
+          .with(jwtForUser(userId))
+          .exchange();
+      assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void should_Return400_When_MonthMissing() {
+      var result = mvc.get().uri("/v1/transactions/summary?currency=EUR")
+          .with(jwtForUser(userId))
+          .exchange();
+      assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void should_Return400_When_CurrencyMissing() {
+      var result = mvc.get().uri("/v1/transactions/summary?month=2026-03")
+          .with(jwtForUser(userId))
+          .exchange();
+      assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+  }
+
+}

--- a/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionController.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionController.java
@@ -27,11 +27,21 @@ public class TransactionController
 
   private final TransactionService service;
   private final TransactionMapper mapper;
+  private final TransactionSummaryService summaryService;
 
-  public TransactionController(TransactionService service, TransactionMapper mapper) {
+  public TransactionController(
+      TransactionService service,
+      TransactionMapper mapper,
+      TransactionSummaryService summaryService) {
     super(service, mapper);
     this.service = service;
     this.mapper = mapper;
+    this.summaryService = summaryService;
+  }
+
+  @Override
+  public ResponseEntity<MonthlySummary> getTransactionsSummary(String month, String currency) {
+    return ResponseEntity.ok(summaryService.getSummary(month, currency));
   }
 
   @Override

--- a/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionSummaryRepository.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionSummaryRepository.java
@@ -1,0 +1,48 @@
+package com.budget.buddy.budget_buddy_api.transaction;
+
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Repository
+public class TransactionSummaryRepository {
+
+  private static final String SUMMARY_SQL = """
+      SELECT
+          COALESCE(SUM(amount) FILTER (WHERE currency = :currency AND type = 'INCOME'),  0) AS income,
+          COALESCE(SUM(amount) FILTER (WHERE currency = :currency AND type = 'EXPENSE'), 0) AS expense,
+          COALESCE(COUNT(*)    FILTER (WHERE currency = :currency AND type = 'INCOME'),  0) AS income_count,
+          COALESCE(COUNT(*)    FILTER (WHERE currency = :currency AND type = 'EXPENSE'), 0) AS expense_count,
+          COALESCE(COUNT(*)    FILTER (WHERE currency <> :currency),                     0) AS excluded_count
+      FROM transactions
+      WHERE owner_id = :ownerId
+        AND date BETWEEN :monthStart AND :monthEnd
+      """;
+
+  private final JdbcClient jdbcClient;
+
+  public TransactionSummaryRepository(JdbcClient jdbcClient) {
+    this.jdbcClient = jdbcClient;
+  }
+
+  public TransactionSummaryRow getSummary(
+      UUID ownerId, LocalDate monthStart, LocalDate monthEnd, String currency) {
+
+    return jdbcClient.sql(SUMMARY_SQL)
+        .param("ownerId", ownerId)
+        .param("monthStart", monthStart)
+        .param("monthEnd", monthEnd)
+        .param("currency", currency)
+        .query((rs, _) -> new TransactionSummaryRow(
+            rs.getLong("income"),
+            rs.getLong("expense"),
+            rs.getInt("income_count"),
+            rs.getInt("expense_count"),
+            rs.getInt("excluded_count")
+        ))
+        .single();
+  }
+
+}

--- a/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionSummaryRow.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionSummaryRow.java
@@ -1,0 +1,9 @@
+package com.budget.buddy.budget_buddy_api.transaction;
+
+record TransactionSummaryRow(
+    long income,
+    long expense,
+    int incomeCount,
+    int expenseCount,
+    int excludedCount
+) {}

--- a/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionSummaryService.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionSummaryService.java
@@ -1,0 +1,45 @@
+package com.budget.buddy.budget_buddy_api.transaction;
+
+import com.budget.buddy.budget_buddy_api.base.crudl.ownable.OwnerIdProvider;
+import com.budget.buddy.budget_buddy_contracts.generated.model.MonthlySummary;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.YearMonth;
+import java.time.format.DateTimeParseException;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TransactionSummaryService {
+
+  private final TransactionSummaryRepository repository;
+  private final OwnerIdProvider<UUID> ownerIdProvider;
+
+  public MonthlySummary getSummary(String month, String currency) {
+    var yearMonth = parseMonth(month);
+    var row = repository.getSummary(
+        ownerIdProvider.get(), yearMonth.atDay(1), yearMonth.atEndOfMonth(), currency);
+    return new MonthlySummary(
+        month,
+        currency,
+        row.income(),
+        row.expense(),
+        row.income() - row.expense(),
+        row.incomeCount(),
+        row.expenseCount(),
+        row.excludedCount()
+    );
+  }
+
+  private static YearMonth parseMonth(String month) {
+    try {
+      return YearMonth.parse(month);
+    } catch (DateTimeParseException e) {
+      throw new IllegalArgumentException("Invalid month format: " + month, e);
+    }
+  }
+
+}


### PR DESCRIPTION
## Why

Closes #159. The web dashboard currently fan-outs a paginated `listTransactions` query (capped at 2,000 rows) on every mount just to compute three monthly totals. Contracts v3.4.0 added `GET /v1/transactions/summary` so we can aggregate server-side. This PR implements the endpoint.

## What changed

- **Bump** `budget-buddy-contracts` 3.3.0 → 3.4.0 ([build.gradle.kts](build.gradle.kts))
- **New** `TransactionSummaryRepository` — single `JdbcClient` query using PostgreSQL `FILTER` clauses for income/expense sums + counts plus an excluded-currency count
- **New** `TransactionSummaryService` — `OwnerIdProvider`-scoped, UTC month boundaries (`YearMonth.atDay(1)` / `atEndOfMonth`), parses `YYYY-MM` and rethrows `IllegalArgumentException` (→ 400 via `GlobalExceptionHandler`)
- **New** package-private `TransactionSummaryRow` record
- **Wire** `TransactionController.getTransactionsSummary(month, currency)` to the generated `TransactionsApi` interface
- **New** `TransactionSummaryIntegrationTest` covering all required cases

Mirrors the existing `categories/summary` patterns (`CategorySummaryRepository`/`Service`) — no new conventions introduced.

## Acceptance criteria

- ✅ Bump `budget-buddy-contracts` to the new version
- ✅ Implement controller method on the generated `TransactionsApi`
- ✅ Service-layer aggregation scoped to authenticated user's `ownerId`
- ✅ Sum only matching currency; mismatched → `excludedTransactionCount`
- ✅ Month interpreted in UTC (matches `getCategoriesSummary`)
- ✅ 400 for malformed `month`/`currency` (Bean Validation on generated DTOs + `IllegalArgumentException` for invalid `YearMonth`)
- ✅ Aggregation done in SQL, no in-memory load
- ✅ Integration tests: matching-currency sums, mismatched exclusion, empty month, unauthenticated → 401, plus boundary dates and owner isolation

## How to verify

```bash
export GITHUB_ACTOR=<user> GITHUB_TOKEN=<pat-with-read:packages>
./gradlew check                                       # all tests pass
./gradlew integrationTest --tests "*TransactionSummary*"
```

Manual smoke (with `bootRun --args='--spring.profiles.active=dev'`):
```bash
curl -H "Authorization: Bearer <jwt>" \
  'http://localhost:8080/v1/transactions/summary?month=2026-05&currency=EUR'
```

## Notes

Web-app consumer PR: filed against `budget-buddy-web-app` (closes #136 there). Should land after this one is merged and deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)