### PR TITLE
feat: implement GET /v1/transactions/summary/trend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,39 @@ Or add `gpr.user` / `gpr.key` to `~/.gradle/gradle.properties`.
   - **Read-Only Operations**: All service-level read operations (e.g., `read`, `list`, `count`) MUST be marked with `@Transactional(readOnly = true)`.
   - **Class-Level Default**: Prefer setting `@Transactional(readOnly = true)` at the class level and overriding it with `@Transactional` on specific write methods (create, update, delete).
 
+### Entity Column Constants
+
+Entities owned by this service expose their table and column names as `public static final String` constants and
+reference them from `@Table` / `@Column` annotations. This keeps a single source of truth for column names and lets
+repositories that build queries programmatically (e.g. via Spring Data Criteria, Sort) refer to them in a refactor-safe
+way.
+
+- Add a `TABLE` constant (used in `@Table(MyEntity.TABLE)`).
+- Add one constant per persisted column (used in `@Column(COL_NAME)`).
+- Examples: `TransactionEntity`, `CategoryEntity`. `TransactionPagingRepositoryImpl` consumes these via
+  `Criteria.where(TransactionEntity.OWNER_ID)…`.
+
+Raw SQL repositories (text-block queries) intentionally keep literal column names in the SQL itself for readability and
+copy-paste-into-`psql` debuggability — entity constants are not interpolated into text blocks.
+
+### Raw SQL Repositories (`JdbcClient`)
+
+When a query is too dynamic or aggregate-heavy for Spring Data JDBC, drop down to `JdbcClient` with text-block SQL.
+Examples: `TransactionSummaryRepository`, `CategorySummaryRepository`. Conventions:
+
+- **Named parameters as constants**: lift each `:bindingName` into a `private static final String` constant. The
+  constant is used in both the SQL literal and the `.param(NAME, value)` call so renames stay in sync.
+- **Extract `RowMapper`s**: declare each `RowMapper<T>` as a `private static final` field rather than inline lambdas.
+  Reuse mappers when one row type is built from another (e.g. a bucketed mapper delegating to a per-row mapper via
+  `mapRow`).
+- **Result alias literals**: SELECT-list aliases (e.g. `AS income_count`) stay literal — they're query-local artifacts,
+  not part of the persistent schema.
+- **Stream over list**: prefer `.query(mapper).stream().collect(...)` over `.list().stream()` to avoid materializing an
+  intermediate list when collecting to a different shape (e.g. `Map`).
+- **Return value objects**: repositories return small `record`s (e.g. `TransactionSummaryRow`,
+  `TransactionTrendBucket`), not API DTOs. The service layer maps to contract types and handles cross-row concerns like
+  zero-filling missing buckets.
+
 ---
 
 ## Development Notes

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
   val mapstructVersion = "1.6.3"
   val lombokMapstructBindingVersion = "0.2.0"
   val jacksonDatabindNullableVersion = "0.2.10"
-  val budgetBuddyContractsVersion = "3.4.0"
+  val budgetBuddyContractsVersion = "4.0.0"
   implementation("com.budgetbuddy:budget-buddy-contracts:${budgetBuddyContractsVersion}")
   implementation("org.springframework.boot:spring-boot-starter-webmvc")
   implementation("org.springframework.boot:spring-boot-starter-security")

--- a/src/integrationTest/java/com/budget/buddy/budget_buddy_api/transaction/TransactionSummaryIntegrationTest.java
+++ b/src/integrationTest/java/com/budget/buddy/budget_buddy_api/transaction/TransactionSummaryIntegrationTest.java
@@ -1,40 +1,54 @@
 package com.budget.buddy.budget_buddy_api.transaction;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.budget.buddy.budget_buddy_api.BaseMvcIntegrationTest;
-import com.budget.buddy.budget_buddy_contracts.generated.model.CategoryWrite;
-import com.budget.buddy.budget_buddy_contracts.generated.model.MonthlySummary;
+import com.budget.buddy.budget_buddy_contracts.generated.model.*;
 import com.budget.buddy.budget_buddy_contracts.generated.model.TransactionType;
-import com.budget.buddy.budget_buddy_contracts.generated.model.TransactionWrite;
-import java.time.LocalDate;
-import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import tools.jackson.core.type.TypeReference;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static com.budget.buddy.budget_buddy_contracts.generated.model.TransactionType.EXPENSE;
+import static com.budget.buddy.budget_buddy_contracts.generated.model.TransactionType.INCOME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 class TransactionSummaryIntegrationTest extends BaseMvcIntegrationTest {
+
+  private static final String EUR = "EUR";
+  private static final String USD = "USD";
+  private static final String GBP = "GBP";
+  private static final String MARCH = "2026-03";
 
   private String userId;
   private String otherUserId;
 
+  @BeforeEach
+  void setUp() {
+    userId = createTestUser();
+    otherUserId = createTestUser();
+  }
+
   // ── helpers ────────────────────────────────────────────────────────────────
 
   private UUID createCategory(String ownerId, String name) throws Exception {
-    var body = new CategoryWrite().name(name).monthlyBudget(null);
     var result = mvc.post().uri("/v1/categories")
         .with(jwtForUser(ownerId))
         .contentType(MediaType.APPLICATION_JSON)
-        .content(json(body))
+        .content(json(new CategoryWrite().name(name)))
         .exchange();
-    return parseBody(result, com.budget.buddy.budget_buddy_contracts.generated.model.Category.class).getId();
+    return parseBody(result, Category.class).getId();
   }
 
   private void createTransaction(
       String ownerId, UUID categoryId, long amount, TransactionType type, String currency, LocalDate date
-  ) throws Exception {
+  ) {
     var body = new TransactionWrite()
         .categoryId(categoryId)
         .amount(amount)
@@ -48,18 +62,22 @@ class TransactionSummaryIntegrationTest extends BaseMvcIntegrationTest {
         .exchange();
   }
 
-  private MonthlySummary getSummary(String ownerId, String month, String currency) throws Exception {
-    var result = mvc.get().uri("/v1/transactions/summary?month={m}&currency={c}", month, currency)
+  private MonthlySummary getSummary(String ownerId) throws Exception {
+    var result = mvc.get().uri("/v1/transactions/summary?month={m}&currency={c}", TransactionSummaryIntegrationTest.MARCH, TransactionSummaryIntegrationTest.EUR)
         .with(jwtForUser(ownerId))
         .exchange();
     assertThat(result).hasStatus(HttpStatus.OK);
     return parseBody(result, MonthlySummary.class);
   }
 
-  @BeforeEach
-  void setUp() {
-    userId = createTestUser();
-    otherUserId = createTestUser();
+  private List<MonthlySummary> getTrend(String ownerId, String from) throws Exception {
+    var result = mvc.get().uri("/v1/transactions/summary/trend?from={f}&to={t}&currency={c}", from, TransactionSummaryIntegrationTest.MARCH, TransactionSummaryIntegrationTest.EUR)
+        .with(jwtForUser(ownerId))
+        .exchange();
+    assertThat(result).hasStatus(HttpStatus.OK);
+    return objectMapper.readValue(
+        result.getResponse().getContentAsString(),
+        new TypeReference<>() {});
   }
 
   // ── tests ──────────────────────────────────────────────────────────────────
@@ -69,16 +87,17 @@ class TransactionSummaryIntegrationTest extends BaseMvcIntegrationTest {
 
     @Test
     void should_ReturnZeros_When_NoTransactions() throws Exception {
-      var summary = getSummary(userId, "2026-03", "EUR");
+      var summary = getSummary(userId);
 
-      assertThat(summary.getMonth()).isEqualTo("2026-03");
-      assertThat(summary.getCurrency()).isEqualTo("EUR");
-      assertThat(summary.getIncome()).isEqualTo(0L);
-      assertThat(summary.getExpense()).isEqualTo(0L);
-      assertThat(summary.getBalance()).isEqualTo(0L);
-      assertThat(summary.getIncomeCount()).isEqualTo(0);
-      assertThat(summary.getExpenseCount()).isEqualTo(0);
-      assertThat(summary.getExcludedTransactionCount()).isEqualTo(0);
+      assertThat(summary)
+          .returns(MARCH, MonthlySummary::getMonth)
+          .returns(EUR, MonthlySummary::getCurrency)
+          .returns(0L, MonthlySummary::getIncome)
+          .returns(0L, MonthlySummary::getExpense)
+          .returns(0L, MonthlySummary::getBalance)
+          .returns(0, MonthlySummary::getIncomeCount)
+          .returns(0, MonthlySummary::getExpenseCount)
+          .returns(0, MonthlySummary::getExcludedTransactionCount);
     }
   }
 
@@ -88,18 +107,19 @@ class TransactionSummaryIntegrationTest extends BaseMvcIntegrationTest {
     @Test
     void should_SumIncomeAndExpenseSeparately_AndComputeBalance() throws Exception {
       var catId = createCategory(userId, "Misc");
-      createTransaction(userId, catId, 5000L, TransactionType.INCOME, "EUR", LocalDate.of(2026, 3, 5));
-      createTransaction(userId, catId, 2500L, TransactionType.INCOME, "EUR", LocalDate.of(2026, 3, 12));
-      createTransaction(userId, catId, 1000L, TransactionType.EXPENSE, "EUR", LocalDate.of(2026, 3, 15));
+      createTransaction(userId, catId, 5000L, INCOME, EUR, LocalDate.of(2026, 3, 5));
+      createTransaction(userId, catId, 2500L, INCOME, EUR, LocalDate.of(2026, 3, 12));
+      createTransaction(userId, catId, 1000L, EXPENSE, EUR, LocalDate.of(2026, 3, 15));
 
-      var summary = getSummary(userId, "2026-03", "EUR");
+      var summary = getSummary(userId);
 
-      assertThat(summary.getIncome()).isEqualTo(7500L);
-      assertThat(summary.getExpense()).isEqualTo(1000L);
-      assertThat(summary.getBalance()).isEqualTo(6500L);
-      assertThat(summary.getIncomeCount()).isEqualTo(2);
-      assertThat(summary.getExpenseCount()).isEqualTo(1);
-      assertThat(summary.getExcludedTransactionCount()).isEqualTo(0);
+      assertThat(summary)
+          .returns(7500L, MonthlySummary::getIncome)
+          .returns(1000L, MonthlySummary::getExpense)
+          .returns(6500L, MonthlySummary::getBalance)
+          .returns(2, MonthlySummary::getIncomeCount)
+          .returns(1, MonthlySummary::getExpenseCount)
+          .returns(0, MonthlySummary::getExcludedTransactionCount);
     }
   }
 
@@ -109,19 +129,20 @@ class TransactionSummaryIntegrationTest extends BaseMvcIntegrationTest {
     @Test
     void should_SumMatchingCurrency_And_CountOthersAsExcluded() throws Exception {
       var catId = createCategory(userId, "Travel");
-      createTransaction(userId, catId, 2000L, TransactionType.EXPENSE, "EUR", LocalDate.of(2026, 3, 10));
-      createTransaction(userId, catId, 4000L, TransactionType.INCOME, "EUR", LocalDate.of(2026, 3, 11));
-      createTransaction(userId, catId, 3000L, TransactionType.EXPENSE, "USD", LocalDate.of(2026, 3, 10));
-      createTransaction(userId, catId, 500L, TransactionType.INCOME, "GBP", LocalDate.of(2026, 3, 11));
+      createTransaction(userId, catId, 2000L, EXPENSE, EUR, LocalDate.of(2026, 3, 10));
+      createTransaction(userId, catId, 4000L, INCOME, EUR, LocalDate.of(2026, 3, 11));
+      createTransaction(userId, catId, 3000L, EXPENSE, USD, LocalDate.of(2026, 3, 10));
+      createTransaction(userId, catId, 500L, INCOME, GBP, LocalDate.of(2026, 3, 11));
 
-      var summary = getSummary(userId, "2026-03", "EUR");
+      var summary = getSummary(userId);
 
-      assertThat(summary.getIncome()).isEqualTo(4000L);
-      assertThat(summary.getExpense()).isEqualTo(2000L);
-      assertThat(summary.getBalance()).isEqualTo(2000L);
-      assertThat(summary.getIncomeCount()).isEqualTo(1);
-      assertThat(summary.getExpenseCount()).isEqualTo(1);
-      assertThat(summary.getExcludedTransactionCount()).isEqualTo(2);
+      assertThat(summary)
+          .returns(4000L, MonthlySummary::getIncome)
+          .returns(2000L, MonthlySummary::getExpense)
+          .returns(2000L, MonthlySummary::getBalance)
+          .returns(1, MonthlySummary::getIncomeCount)
+          .returns(1, MonthlySummary::getExpenseCount)
+          .returns(2, MonthlySummary::getExcludedTransactionCount);
     }
   }
 
@@ -131,15 +152,16 @@ class TransactionSummaryIntegrationTest extends BaseMvcIntegrationTest {
     @Test
     void should_IncludeBoundaryTransactions_When_OnFirstAndLastDayOfMonth() throws Exception {
       var catId = createCategory(userId, "Bills");
-      createTransaction(userId, catId, 100L, TransactionType.EXPENSE, "EUR", LocalDate.of(2026, 3, 1));
-      createTransaction(userId, catId, 200L, TransactionType.EXPENSE, "EUR", LocalDate.of(2026, 3, 31));
-      createTransaction(userId, catId, 999L, TransactionType.EXPENSE, "EUR", LocalDate.of(2026, 2, 28));
-      createTransaction(userId, catId, 999L, TransactionType.EXPENSE, "EUR", LocalDate.of(2026, 4, 1));
+      createTransaction(userId, catId, 100L, EXPENSE, EUR, LocalDate.of(2026, 3, 1));
+      createTransaction(userId, catId, 200L, EXPENSE, EUR, LocalDate.of(2026, 3, 31));
+      createTransaction(userId, catId, 999L, EXPENSE, EUR, LocalDate.of(2026, 2, 28));
+      createTransaction(userId, catId, 999L, EXPENSE, EUR, LocalDate.of(2026, 4, 1));
 
-      var summary = getSummary(userId, "2026-03", "EUR");
+      var summary = getSummary(userId);
 
-      assertThat(summary.getExpense()).isEqualTo(300L);
-      assertThat(summary.getExpenseCount()).isEqualTo(2);
+      assertThat(summary)
+          .returns(300L, MonthlySummary::getExpense)
+          .returns(2, MonthlySummary::getExpenseCount);
     }
   }
 
@@ -150,16 +172,17 @@ class TransactionSummaryIntegrationTest extends BaseMvcIntegrationTest {
     void should_NotCountOtherUsersTransactions() throws Exception {
       var myCat = createCategory(userId, "Mine");
       var otherCat = createCategory(otherUserId, "Other");
-      createTransaction(userId, myCat, 1000L, TransactionType.EXPENSE, "EUR", LocalDate.of(2026, 3, 10));
-      createTransaction(otherUserId, otherCat, 9999L, TransactionType.EXPENSE, "EUR", LocalDate.of(2026, 3, 10));
-      createTransaction(otherUserId, otherCat, 8888L, TransactionType.INCOME, "EUR", LocalDate.of(2026, 3, 10));
+      createTransaction(userId, myCat, 1000L, EXPENSE, EUR, LocalDate.of(2026, 3, 10));
+      createTransaction(otherUserId, otherCat, 9999L, EXPENSE, EUR, LocalDate.of(2026, 3, 10));
+      createTransaction(otherUserId, otherCat, 8888L, INCOME, EUR, LocalDate.of(2026, 3, 10));
 
-      var summary = getSummary(userId, "2026-03", "EUR");
+      var summary = getSummary(userId);
 
-      assertThat(summary.getExpense()).isEqualTo(1000L);
-      assertThat(summary.getIncome()).isEqualTo(0L);
-      assertThat(summary.getExpenseCount()).isEqualTo(1);
-      assertThat(summary.getIncomeCount()).isEqualTo(0);
+      assertThat(summary)
+          .returns(1000L, MonthlySummary::getExpense)
+          .returns(0L, MonthlySummary::getIncome)
+          .returns(1, MonthlySummary::getExpenseCount)
+          .returns(0, MonthlySummary::getIncomeCount);
     }
   }
 
@@ -205,4 +228,114 @@ class TransactionSummaryIntegrationTest extends BaseMvcIntegrationTest {
     }
   }
 
+  @Nested
+  class Trend {
+
+    @Test
+    void should_ReturnOneBucketPerMonth_OldestFirst() throws Exception {
+      var catId = createCategory(userId, "Misc");
+      createTransaction(userId, catId, 1000L, EXPENSE, EUR, LocalDate.of(2026, 1, 5));
+      createTransaction(userId, catId, 2000L, INCOME, EUR, LocalDate.of(2026, 2, 12));
+      createTransaction(userId, catId, 500L, EXPENSE, EUR, LocalDate.of(2026, 3, 20));
+
+      var trend = getTrend(userId, "2026-01");
+
+      assertThat(trend)
+          .extracting(MonthlySummary::getMonth, MonthlySummary::getIncome, MonthlySummary::getExpense)
+          .containsExactly(
+              tuple("2026-01", 0L, 1000L),
+              tuple("2026-02", 2000L, 0L),
+              tuple(MARCH, 0L, 500L));
+    }
+
+    @Test
+    void should_ZeroFillEmptyMonths() throws Exception {
+      var catId = createCategory(userId, "Misc");
+      // Only Jan and Mar have transactions; Feb is empty.
+      createTransaction(userId, catId, 1000L, EXPENSE, EUR, LocalDate.of(2026, 1, 5));
+      createTransaction(userId, catId, 500L, EXPENSE, EUR, LocalDate.of(2026, 3, 20));
+
+      var trend = getTrend(userId, "2026-01");
+
+      assertThat(trend).hasSize(3);
+      assertThat(trend.get(1))
+          .returns("2026-02", MonthlySummary::getMonth)
+          .returns(0L, MonthlySummary::getIncome)
+          .returns(0L, MonthlySummary::getExpense)
+          .returns(0L, MonthlySummary::getBalance)
+          .returns(0, MonthlySummary::getIncomeCount)
+          .returns(0, MonthlySummary::getExpenseCount)
+          .returns(0, MonthlySummary::getExcludedTransactionCount)
+          .returns(EUR, MonthlySummary::getCurrency);
+    }
+
+    @Test
+    void should_ReturnSingleBucket_When_FromEqualsTo() throws Exception {
+      var catId = createCategory(userId, "Misc");
+      createTransaction(userId, catId, 7500L, INCOME, EUR, LocalDate.of(2026, 3, 5));
+
+      var trend = getTrend(userId, MARCH);
+
+      assertThat(trend)
+          .singleElement()
+          .returns(MARCH, MonthlySummary::getMonth)
+          .returns(7500L, MonthlySummary::getIncome);
+    }
+
+    @Test
+    void should_NotIncludeOtherUsersTransactions() throws Exception {
+      var myCat = createCategory(userId, "Mine");
+      var otherCat = createCategory(otherUserId, "Other");
+      createTransaction(userId, myCat, 1000L, EXPENSE, EUR, LocalDate.of(2026, 2, 10));
+      createTransaction(otherUserId, otherCat, 9999L, EXPENSE, EUR, LocalDate.of(2026, 2, 10));
+
+      var trend = getTrend(userId, "2026-01");
+
+      assertThat(trend)
+          .extracting(MonthlySummary::getMonth, MonthlySummary::getExpense)
+          .containsExactly(
+              tuple("2026-01", 0L),
+              tuple("2026-02", 1000L),
+              tuple(MARCH, 0L));
+    }
+
+    @Test
+    void should_Return400_When_FromAfterTo() {
+      var result = mvc.get().uri("/v1/transactions/summary/trend?from=2026-05&to=2026-03&currency=EUR")
+          .with(jwtForUser(userId))
+          .exchange();
+      assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void should_Return400_When_RangeExceedsCap() {
+      // 25 months (Jan 2024 → Jan 2026 inclusive) > 24-month cap.
+      var result = mvc.get().uri("/v1/transactions/summary/trend?from=2024-01&to=2026-01&currency=EUR")
+          .with(jwtForUser(userId))
+          .exchange();
+      assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void should_Return400_When_FromMalformed() {
+      var result = mvc.get().uri("/v1/transactions/summary/trend?from=2026-13&to=2026-05&currency=EUR")
+          .with(jwtForUser(userId))
+          .exchange();
+      assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void should_Return400_When_FromMissing() {
+      var result = mvc.get().uri("/v1/transactions/summary/trend?to=2026-05&currency=EUR")
+          .with(jwtForUser(userId))
+          .exchange();
+      assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void should_Return401_When_NotAuthenticated() {
+      var result = mvc.get().uri("/v1/transactions/summary/trend?from=2026-01&to=2026-03&currency=EUR").exchange();
+      assertThat(result).hasStatus(HttpStatus.UNAUTHORIZED);
+    }
+  }
 }

--- a/src/main/java/com/budget/buddy/budget_buddy_api/category/CategoryEntity.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/category/CategoryEntity.java
@@ -16,24 +16,30 @@ import java.util.UUID;
 /**
  * Category entity representing a budget category for organizing transactions. Uses Spring Data JDBC for data access.
  */
-@Table("categories")
+@Table(CategoryEntity.TABLE)
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class CategoryEntity extends AuditableEntity implements OwnableEntity<UUID> {
 
+  public static final String TABLE = "categories";
+  public static final String ID = "id";
+  public static final String NAME = "name";
+  public static final String OWNER_ID = "owner_id";
+  public static final String MONTHLY_BUDGET = "monthly_budget";
+
   @Id
-  @Column("id")
+  @Column(ID)
   private UUID id;
 
-  @Column("name")
+  @Column(NAME)
   private String name;
 
-  @Column("owner_id")
+  @Column(OWNER_ID)
   private UUID ownerId;
 
-  @Column("monthly_budget")
+  @Column(MONTHLY_BUDGET)
   private @Nullable Long monthlyBudget;
 
 }

--- a/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionController.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -42,6 +43,12 @@ public class TransactionController
   @Override
   public ResponseEntity<MonthlySummary> getTransactionsSummary(String month, String currency) {
     return ResponseEntity.ok(summaryService.getSummary(month, currency));
+  }
+
+  @Override
+  public ResponseEntity<List<MonthlySummary>> getTransactionsSummaryTrend(
+      String from, String to, String currency) {
+    return ResponseEntity.ok(summaryService.getTrend(from, to, currency));
   }
 
   @Override

--- a/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionEntity.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionEntity.java
@@ -17,22 +17,25 @@ import java.util.UUID;
 /**
  * Transaction entity representing a financial transaction. Uses Spring Data JDBC for data access.
  */
-@Table("transactions")
+@Table(TransactionEntity.TABLE)
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class TransactionEntity extends AuditableEntity implements OwnableEntity<UUID> {
 
+  public static final String TABLE = "transactions";
+  public static final String ID = "id";
   public static final String CATEGORY_ID = "category_id";
   public static final String AMOUNT = "amount";
   public static final String TYPE = "type";
+  public static final String CURRENCY = "currency";
   public static final String DATE = "date";
   public static final String DESCRIPTION = "description";
   public static final String OWNER_ID = "owner_id";
 
   @Id
-  @Column("id")
+  @Column(ID)
   private UUID id;
 
   @Column(CATEGORY_ID)
@@ -44,7 +47,7 @@ public class TransactionEntity extends AuditableEntity implements OwnableEntity<
   @Column(TYPE)
   private TransactionType type;
 
-  @Column("currency")
+  @Column(CURRENCY)
   private Currency currency;
 
   @Column(DATE)

--- a/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionSummaryRepository.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionSummaryRepository.java
@@ -1,13 +1,42 @@
 package com.budget.buddy.budget_buddy_api.transaction;
 
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
+/**
+ * Aggregates over the {@code transactions} table for the authenticated user. Issues raw SQL
+ * via {@link JdbcClient} so the database does the per-currency, per-type aggregation in a
+ * single round-trip; callers receive value-object rows ready for mapping to API DTOs.
+ */
 @Repository
 public class TransactionSummaryRepository {
+
+  private static final String OWNER_ID = "ownerId";
+  private static final String CURRENCY = "currency";
+  private static final String RANGE_START = "rangeStart";
+  private static final String RANGE_END = "rangeEnd";
+
+  private static final RowMapper<TransactionSummaryRow> TRANSACTION_SUMMARY_ROW_ROW_MAPPER = (rs, _) ->
+      new TransactionSummaryRow(
+          rs.getLong("income"),
+          rs.getLong("expense"),
+          rs.getInt("income_count"),
+          rs.getInt("expense_count"),
+          rs.getInt("excluded_count")
+      );
+
+  private static final RowMapper<TransactionTrendBucket> TREND_BUCKET_ROW_MAPPER = (rs, rowNum) ->
+      new TransactionTrendBucket(
+          YearMonth.from(rs.getDate("month_start").toLocalDate()),
+          TRANSACTION_SUMMARY_ROW_ROW_MAPPER.mapRow(rs, rowNum)
+      );
 
   private static final String SUMMARY_SQL = """
       SELECT
@@ -18,7 +47,21 @@ public class TransactionSummaryRepository {
           COALESCE(COUNT(*)    FILTER (WHERE currency <> :currency),                     0) AS excluded_count
       FROM transactions
       WHERE owner_id = :ownerId
-        AND date BETWEEN :monthStart AND :monthEnd
+        AND date BETWEEN :rangeStart AND :rangeEnd
+      """;
+
+  private static final String TREND_SQL = """
+      SELECT
+          date_trunc('month', date)::date                                                   AS month_start,
+          COALESCE(SUM(amount) FILTER (WHERE currency = :currency AND type = 'INCOME'),  0) AS income,
+          COALESCE(SUM(amount) FILTER (WHERE currency = :currency AND type = 'EXPENSE'), 0) AS expense,
+          COALESCE(COUNT(*)    FILTER (WHERE currency = :currency AND type = 'INCOME'),  0) AS income_count,
+          COALESCE(COUNT(*)    FILTER (WHERE currency = :currency AND type = 'EXPENSE'), 0) AS expense_count,
+          COALESCE(COUNT(*)    FILTER (WHERE currency <> :currency),                     0) AS excluded_count
+      FROM transactions
+      WHERE owner_id = :ownerId
+        AND date BETWEEN :rangeStart AND :rangeEnd
+      GROUP BY 1
       """;
 
   private final JdbcClient jdbcClient;
@@ -27,22 +70,39 @@ public class TransactionSummaryRepository {
     this.jdbcClient = jdbcClient;
   }
 
+  /**
+   * Aggregate transactions across the inclusive {@code [rangeStart, rangeEnd]} date window into
+   * a single row of income / expense totals and counts, scoped to the authenticated owner.
+   * Transactions in other currencies are tallied into {@code excludedCount}.
+   */
   public TransactionSummaryRow getSummary(
-      UUID ownerId, LocalDate monthStart, LocalDate monthEnd, String currency) {
+      UUID ownerId, LocalDate rangeStart, LocalDate rangeEnd, String currency) {
 
     return jdbcClient.sql(SUMMARY_SQL)
-        .param("ownerId", ownerId)
-        .param("monthStart", monthStart)
-        .param("monthEnd", monthEnd)
-        .param("currency", currency)
-        .query((rs, _) -> new TransactionSummaryRow(
-            rs.getLong("income"),
-            rs.getLong("expense"),
-            rs.getInt("income_count"),
-            rs.getInt("expense_count"),
-            rs.getInt("excluded_count")
-        ))
+        .param(OWNER_ID, ownerId)
+        .param(RANGE_START, rangeStart)
+        .param(RANGE_END, rangeEnd)
+        .param(CURRENCY, currency)
+        .query(TRANSACTION_SUMMARY_ROW_ROW_MAPPER)
         .single();
+  }
+
+  /**
+   * Aggregate transactions per calendar month across the range. Months with no
+   * matching transactions are absent from the result; callers are responsible
+   * for zero-filling so the response array length matches the requested range.
+   */
+  public Map<YearMonth, TransactionSummaryRow> getTrend(
+      UUID ownerId, LocalDate rangeStart, LocalDate rangeEnd, String currency) {
+
+    return jdbcClient.sql(TREND_SQL)
+        .param(OWNER_ID, ownerId)
+        .param(RANGE_START, rangeStart)
+        .param(RANGE_END, rangeEnd)
+        .param(CURRENCY, currency)
+        .query(TREND_BUCKET_ROW_MAPPER)
+        .stream()
+        .collect(Collectors.toUnmodifiableMap(TransactionTrendBucket::month, TransactionTrendBucket::row));
   }
 
 }

--- a/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionSummaryRow.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionSummaryRow.java
@@ -1,6 +1,11 @@
 package com.budget.buddy.budget_buddy_api.transaction;
 
-record TransactionSummaryRow(
+/**
+ * Raw aggregate row returned by transaction summary queries: amounts in minor units,
+ * counts as exact integers. {@code excludedCount} reports transactions in other
+ * currencies that were filtered out of the income / expense totals.
+ */
+public record TransactionSummaryRow(
     long income,
     long expense,
     int incomeCount,

--- a/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionSummaryService.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionSummaryService.java
@@ -8,22 +8,81 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.YearMonth;
 import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
+/**
+ * Builds {@link MonthlySummary} responses from raw transaction aggregates. Owns parsing of
+ * the {@code YYYY-MM} string inputs, range validation, the empty-month zero-fill on trend
+ * queries, and the final {@link TransactionSummaryRow} → {@link MonthlySummary} mapping.
+ * The repository stays focused on SQL; the controller stays focused on HTTP.
+ */
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class TransactionSummaryService {
 
+  /** Caps the per-request bucket count so a single query can't fan out to arbitrary depth. */
+  static final int MAX_RANGE_MONTHS = 24;
+
+  private static final TransactionSummaryRow EMPTY_ROW = new TransactionSummaryRow(0L, 0L, 0, 0, 0);
+
   private final TransactionSummaryRepository repository;
   private final OwnerIdProvider<UUID> ownerIdProvider;
 
+  /**
+   * Compute the {@link MonthlySummary} for a single calendar month.
+   *
+   * @param month    calendar month formatted {@code YYYY-MM}
+   * @param currency ISO 4217 currency code; only matching transactions contribute to totals
+   * @throws IllegalArgumentException if {@code month} is not a valid {@code YYYY-MM} value
+   */
   public MonthlySummary getSummary(String month, String currency) {
-    var yearMonth = parseMonth(month);
+    var yearMonth = parseMonth(month, "month");
     var row = repository.getSummary(
         ownerIdProvider.get(), yearMonth.atDay(1), yearMonth.atEndOfMonth(), currency);
+    return toMonthlySummary(yearMonth, currency, row);
+  }
+
+  /**
+   * Compute one {@link MonthlySummary} per calendar month across the inclusive
+   * {@code [fromMonth, toMonth]} range, oldest first. Months with no matching transactions
+   * are zero-filled so the returned list always has {@code (toMonth - fromMonth) + 1} elements.
+   *
+   * @param fromMonth first calendar month, inclusive ({@code YYYY-MM})
+   * @param toMonth   last calendar month, inclusive ({@code YYYY-MM})
+   * @param currency  ISO 4217 currency code
+   * @throws IllegalArgumentException if either bound is malformed, {@code fromMonth} is after
+   *                                  {@code toMonth}, or the span exceeds {@link #MAX_RANGE_MONTHS}
+   */
+  public List<MonthlySummary> getTrend(String fromMonth, String toMonth, String currency) {
+    var from = parseMonth(fromMonth, "from");
+    var to = parseMonth(toMonth, "to");
+    if (from.isAfter(to)) {
+      throw new IllegalArgumentException("'from' must be on or before 'to'");
+    }
+    long span = ChronoUnit.MONTHS.between(from, to) + 1;
+    if (span > MAX_RANGE_MONTHS) {
+      throw new IllegalArgumentException(
+          "Range too wide: max " + MAX_RANGE_MONTHS + " months, requested " + span);
+    }
+
+    var byMonth = repository.getTrend(
+        ownerIdProvider.get(), from.atDay(1), to.atEndOfMonth(), currency);
+
+    List<MonthlySummary> out = new ArrayList<>((int) span);
+    for (var ym = from; !ym.isAfter(to); ym = ym.plusMonths(1)) {
+      out.add(toMonthlySummary(ym, currency, byMonth.getOrDefault(ym, EMPTY_ROW)));
+    }
+    return out;
+  }
+
+  private static MonthlySummary toMonthlySummary(
+      YearMonth ym, String currency, TransactionSummaryRow row) {
     return new MonthlySummary(
-        month,
+        ym.toString(),
         currency,
         row.income(),
         row.expense(),
@@ -34,11 +93,12 @@ public class TransactionSummaryService {
     );
   }
 
-  private static YearMonth parseMonth(String month) {
+  private static YearMonth parseMonth(String value, String paramName) {
     try {
-      return YearMonth.parse(month);
+      return YearMonth.parse(value);
     } catch (DateTimeParseException e) {
-      throw new IllegalArgumentException("Invalid month format: " + month, e);
+      throw new IllegalArgumentException(
+          "Invalid '" + paramName + "' format: '" + value + "', expected YYYY-MM", e);
     }
   }
 

--- a/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionTrendBucket.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionTrendBucket.java
@@ -1,0 +1,10 @@
+package com.budget.buddy.budget_buddy_api.transaction;
+
+import java.time.YearMonth;
+
+/**
+ * One calendar-month bucket emitted by the trend query: the month it represents
+ * paired with the aggregated {@link TransactionSummaryRow} for that month.
+ */
+public record TransactionTrendBucket(YearMonth month, TransactionSummaryRow row) {
+}


### PR DESCRIPTION
## Summary

Implements the new `getTransactionsSummaryTrend` endpoint introduced in `budget-buddy-contracts` 4.0.0. Returns one `MonthlySummary` per calendar month across an inclusive `from`/`to` range, oldest first.

## Implementation notes

- Single SQL query with `GROUP BY date_trunc('month', date)` — no fan-out at the data layer.
- Empty months in the range are zero-filled in the service so the response array length always equals `(to - from) + 1`. Clients get a stable bucket count without having to gap-fill themselves.
- Range capped at 24 months (`TransactionSummaryService.MAX_RANGE_MONTHS`) to bound query cost.
- `from > to` and malformed `YYYY-MM` both surface as 400 via `IllegalArgumentException` (existing `GlobalExceptionHandler` mapping).
- `TransactionSummaryRow` → `MonthlySummary` mapping extracted into a shared helper to keep `getSummary` and `getTrend` DRY.
- Repository SQL parameter names normalised: `monthStart`/`monthEnd` → `rangeStart`/`rangeEnd` to match what the methods actually receive in either path.

Bumps `budgetBuddyContractsVersion` from 3.4.0 → 4.0.0.

## Test plan

- [x] `./gradlew check` (unit + integration green)
- [x] New integration tests cover: multi-month range, zero-fill of empty months, single-month range (`from === to`), owner isolation, validation 400s (from > to, range > 24 months, malformed `from`, missing `from`), 401 unauthenticated.
- [ ] Manual `curl` against a deployed instance once merged.

## Rollout

Land before the web app PR consumes the new endpoint — it's currently calling 6 single-month requests via the old hook. Web app PR (`fix(dashboard): remove naive expense projection`) bumps contracts to 4.0.0 and switches the trend hook to a single ranged call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)