### PR TITLE
fix: resolve null local user id on concurrent first login

### DIFF
--- a/src/integrationTest/java/com/budget/buddy/budget_buddy_api/user/UserRepositoryIntegrationTest.java
+++ b/src/integrationTest/java/com/budget/buddy/budget_buddy_api/user/UserRepositoryIntegrationTest.java
@@ -5,7 +5,15 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -49,5 +57,46 @@ class UserRepositoryIntegrationTest extends BaseIntegrationTest {
     assertThat(actual)
         .as("Returned ID should be equal to old ID")
         .isEqualTo(oldId);
+  }
+
+  @Test
+  @DisplayName("Concurrent first logins all resolve to the same non-null id")
+  void upsert_Should_ReturnSameNonNullId_When_ConcurrentFirstLogins() throws Exception {
+    // Given a brand-new OIDC identity that several requests try to provision at once.
+    // The worker threads call the repository outside the test's transaction, so each upsert
+    // commits independently — reproducing the real concurrent first-login race. With the old
+    // ON CONFLICT DO NOTHING query the losing threads got a null id back.
+    var subject = "sub_" + UUID.randomUUID();
+    var issuer = "test_issuer";
+    var threadCount = 16;
+
+    var pool = Executors.newFixedThreadPool(threadCount);
+    var barrier = new CyclicBarrier(threadCount);
+    var tasks = new ArrayList<Callable<UUID>>();
+    for (var i = 0; i < threadCount; i++) {
+      tasks.add(() -> {
+        barrier.await(); // release all threads at once to maximise overlap
+        return userRepository.upsert(UUID.randomUUID(), subject, issuer);
+      });
+    }
+
+    // When
+    List<UUID> results = new ArrayList<>();
+    try {
+      var futures = pool.invokeAll(tasks, 30, TimeUnit.SECONDS);
+      for (Future<UUID> future : futures) {
+        results.add(future.get());
+      }
+    } finally {
+      pool.shutdownNow();
+    }
+
+    // Then every concurrent caller must resolve to the same, non-null user id.
+    assertThat(results)
+        .as("no concurrent first-login upsert should return a null id")
+        .doesNotContainNull();
+    assertThat(results)
+        .as("all concurrent first-login upserts should resolve to the same user id")
+        .containsOnly(results.getFirst());
   }
 }

--- a/src/main/java/com/budget/buddy/budget_buddy_api/user/UserRepository.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/user/UserRepository.java
@@ -12,22 +12,25 @@ import java.util.UUID;
 public interface UserRepository extends Repository<UserEntity, UUID> {
 
   String UPSERT_QUERY = """
-      WITH ins AS (
-        INSERT INTO users (id, oidc_subject, oidc_issuer, version, created_at, updated_at)
-        VALUES (:id, :oidcSubject, :oidcIssuer, 0, NOW(), NOW())
-        ON CONFLICT (oidc_subject, oidc_issuer) DO NOTHING
-        RETURNING id
-      )
-      SELECT id FROM ins
-      UNION ALL
-      SELECT id FROM users
-      WHERE oidc_subject = :oidcSubject AND oidc_issuer = :oidcIssuer
-      LIMIT 1
+      INSERT INTO users (id, oidc_subject, oidc_issuer, version, created_at, updated_at)
+      VALUES (:id, :oidcSubject, :oidcIssuer, 0, NOW(), NOW())
+      ON CONFLICT (oidc_subject, oidc_issuer)
+      DO UPDATE SET updated_at = users.updated_at
+      RETURNING id
       """;
 
   /**
-   * Atomically inserts a new user if no row with the given OIDC subject exists.
-   * Uses {@code ON CONFLICT DO NOTHING ... RETURNING id} so concurrent calls are safe.
+   * Atomically inserts a new user if none exists for the given OIDC identity, returning the
+   * resolved local user id either way.
+   *
+   * <p>Uses {@code ON CONFLICT DO UPDATE ... RETURNING id} (a no-op update that leaves
+   * {@code updated_at} unchanged) rather than {@code DO NOTHING}. {@code DO NOTHING} returns no
+   * row on conflict, so during a concurrent first login — several requests racing before any has
+   * committed — the losing requests would read no row under their pre-commit snapshot and get a
+   * {@code null} id back. With {@code DO UPDATE} the conflicting row is always returned, so every
+   * concurrent caller resolves to the same non-null id. This matters because the dashboard fires
+   * multiple requests in parallel on first load; a null id here propagates as a null
+   * {@code ownerId} and fails every ownable query with a 400.
    *
    * @return {@link UUID} id of the user
    */

--- a/src/main/java/com/budget/buddy/budget_buddy_api/user/UserService.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/user/UserService.java
@@ -37,7 +37,7 @@ public class UserService {
    * @param oidcIssuer the OIDC issuer URI (JWT iss claim)
    * @return the local user's UUID
    */
-  @Cacheable(value = CacheConfig.LOCAL_USER_IDS, key = "#oidcIssuer + '|' + #oidcSubject")
+  @Cacheable(value = CacheConfig.LOCAL_USER_IDS, key = "#oidcIssuer + '|' + #oidcSubject", unless = "#result == null")
   public UUID findOrCreateByOidcSubject(String oidcSubject, String oidcIssuer) {
     log.debug("Resolving local user for OIDC issuer: {}", oidcIssuer);
     return repository.upsert(idGenerator.get(), oidcSubject, oidcIssuer);


### PR DESCRIPTION
## Why

A just-registered user's first dashboard load 400s on `GET /v1/transactions` (and every other ownable endpoint), on both web and iOS. The dashboard fires several requests in parallel; with the provisioning cache cold they all hit `UserRepository.upsert` at once and race.

## What changed

- **`UserRepository.upsert`** — replaced `ON CONFLICT DO NOTHING` + `UNION ALL` fallback with the race-free `ON CONFLICT (...) DO UPDATE SET updated_at = users.updated_at RETURNING id`. Under PostgreSQL READ COMMITTED, the old query returned `null` to the request that lost the insert race: it got `DO NOTHING` (empty CTE) and its statement snapshot predated the winner's commit, so the fallback `SELECT` saw no row either. The null propagated as a null `ownerId`, and `Criteria.where("owner_id").is(null)` throws `IllegalArgumentException("Value must not be null")` → 400. `DO UPDATE` always returns the conflicting row, so every concurrent caller resolves to the same non-null id. The no-op `SET` leaves `updated_at` untouched (login isn't a profile change), and the query is simpler than the old CTE.
- **`UserService.findOrCreateByOidcSubject`** — added `unless = "#result == null"` to `@Cacheable` as defense-in-depth, so a null can never be cached and permanently break a user.
- **`UserRepositoryIntegrationTest`** — new test fires 16 simultaneous first-logins for one identity (worker threads commit independently, reproducing the real race) and asserts they all resolve to the same non-null id.

## How to verify

1. `./gradlew integrationTest --tests "*UserRepositoryIntegrationTest"` — passes.
2. Regression proof: temporarily restore the old `DO NOTHING` query and rerun — the new concurrent test fails (`doesNotContainNull`), confirming it reproduces the bug.
3. End-to-end: register a fresh OIDC user, log in, load the dashboard — no 400.

## Notes

Pre-existing bug, independent of the contracts 6.1.0 / PATCH-sunset work on `feat/sunset-patch-requests`; shipped from `main` so it can merge on its own.