### PR TITLE
refactor: align code and tests with documented conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,29 +6,40 @@ This file provides guidance for AI agents (Claude Code, Junie, etc.) when workin
 
 ## Quick Start
 
-**Stack:** Java 25, Spring Boot 4.0.5, Spring Data JDBC, PostgreSQL, Liquibase, MapStruct, Lombok
+**Stack:** Java 25, Spring Boot 4.0.6, Spring Data JDBC, PostgreSQL, Liquibase, MapStruct, Lombok
 
 **Prerequisites:** The `budget-buddy-contracts` dependency is fetched from GitHub Packages. Set these before building:
+
 ```bash
 export GITHUB_ACTOR=your-github-username
 export GITHUB_TOKEN=your-personal-access-token   # needs read:packages scope
 ```
+
 Or add `gpr.user` / `gpr.key` to `~/.gradle/gradle.properties`.
 
 **Run locally:**
+
 ```bash
 # Automatically starts PostgreSQL via Docker Compose (dev profile)
 ./gradlew bootRun --args='--spring.profiles.active=dev'
 ```
 
-**Test:**
+**Test:** (the `test` suite is unit-only; integration tests run via `integrationTest` and require Docker)
+
 ```bash
-./gradlew test                  # all tests (unit + integration)
-./gradlew integrationTest       # integration tests (requires Docker)
-./gradlew check                 # all tests + quality checks
+./gradlew test                                          # unit tests
+./gradlew integrationTest                               # integration tests (requires Docker)
+./gradlew check                                         # unit + integration tests + JaCoCo coverage report
+./gradlew test --tests "com.budget.buddy.budget_buddy_api.category.CategoryServiceTest"          # single unit test
+./gradlew integrationTest --tests "com.budget.buddy.budget_buddy_api.category.CategoryIntegrationTest"  # single integration test
 ```
 
+See [TESTING.md](TESTING.md) for how to write tests — naming & structure, unit vs. integration policy, and the coverage
+that's mandatory before a change is done (notably auth + cross-user ownership-isolation tests for every ownable
+endpoint).
+
 **Build:**
+
 ```bash
 ./gradlew build
 ```
@@ -40,43 +51,123 @@ Or add `gpr.user` / `gpr.key` to `~/.gradle/gradle.properties`.
 ### Error Handling
 
 - **RFC 9457 (Problem Details)**: All error responses must follow the Problem Details for HTTP APIs specification.
-- **Standardized Titles**: When `type` is `about:blank`, the `title` SHOULD be the same as the HTTP status phrase (e.g., "Bad Request" for 400).
-- **Field-Level Errors**: Validation exceptions (`MethodArgumentNotValidException`, `ConstraintViolationException`) must return a `Problem` containing an `errors` array with `field` and `message` properties.
-- **Request URI**: The `instance` field should contain the current request URI, retrieved using `ServletWebRequest` in `GlobalExceptionHandler`.
+- **Standardized Titles**: When `type` is `about:blank`, the `title` SHOULD be the same as the HTTP status phrase (
+  e.g., "Bad Request" for 400).
+- **Field-Level Errors**: Validation exceptions (`MethodArgumentNotValidException`, `ConstraintViolationException`) must
+  return a `Problem` containing an `errors` array with `field` and `message` properties.
+- **Request URI**: The `instance` field should contain the current request URI, retrieved using `ServletWebRequest` in
+  `GlobalExceptionHandler`.
 
 ### Security & OIDC
 
-- **Stateless resource server**: The API validates JWTs from an external OIDC provider. No sessions, no server-side token storage.
-- **JIT user provisioning**: `OidcUserProvisioningFilter` runs after `BearerTokenAuthenticationFilter` and maps JWT `sub` + `iss` claims to a local user via an atomic upsert. The resolved user UUID is stored as a request attribute.
-- **Multi-issuer support**: Users are identified by the composite `(oidc_subject, oidc_issuer)` unique constraint. The same `sub` from different issuers creates separate users.
+- **Stateless resource server**: The API validates JWTs from an external OIDC provider. No sessions, no server-side
+  token storage.
+- **JIT user provisioning**: `OidcUserProvisioningFilter` runs after `BearerTokenAuthenticationFilter` and maps JWT
+  `sub` + `iss` claims to a local user via an atomic upsert (`UserService.findOrCreateByOidcSubject`, cached). It then
+  replaces the `JwtAuthenticationToken` on the `SecurityContext` with a `LocalUserAuthentication` carrying the resolved
+  local user UUID — the UUID lives in the security context, **not** a request attribute, so it propagates to any
+  context-aware thread.
+- **Multi-issuer support**: Users are identified by the composite `(oidc_subject, oidc_issuer)` unique constraint. The
+  same `sub` from different issuers creates separate users.
 - **Audience validation**: JWTs must contain an expected audience configured via `OIDC_AUDIENCES`.
-- **Ownership isolation**: All ownable entities are scoped to the authenticated user via `OwnerIdProvider<UUID>`, which reads the user UUID set by the provisioning filter.
+- **Ownership isolation**: All ownable entities are scoped to the authenticated user via `OwnerIdProvider<UUID>` (
+  `OidcOwnerIdProvider`), which reads the local user UUID from the `LocalUserAuthentication` on the
+  `SecurityContextHolder`. `OwnableEntityService` applies this owner id to every query and stamps it on create —
+  subclasses inherit isolation with no extra wiring.
 - **No PII in logs**: Never log OIDC subjects or other user-identifying claims at INFO level or above. Use DEBUG.
 
 ### Code Patterns
 
-- **Problem Details Extension**: The base `Problem` class from `budget-buddy-contracts` now includes an `errors` field for field-level validation errors. Use it directly instead of extending it for common validation cases.
+- **Problem Details Extension**: The base `Problem` class from `budget-buddy-contracts` includes an `errors` field for
+  field-level validation errors. Use it directly instead of extending it for common validation cases.
 - **Validation Handling**:
-  - Prefer using `ex.getBindingResult().getFieldErrors()` for `MethodArgumentNotValidException`.
-  - Prefer using `ex.getConstraintViolations()` for `ConstraintViolationException`.
+    - Bean Validation failures on request bodies/params surface as `MethodArgumentNotValidException` /
+      `ConstraintViolationException` → field-level `errors[]`. Prefer `ex.getBindingResult().getFieldErrors()` and
+      `ex.getConstraintViolations()` respectively.
+    - **Domain rules** that need lookups or context (e.g. "category must exist and belong to the caller" in
+      `TransactionValidator`) throw `ValidationException` (`base.exception`), mapped to **400** by
+      `GlobalExceptionHandler`. Use it instead of `IllegalArgumentException` so business-rule failures are distinct from
+      programming errors. The message is surfaced to the client as `detail`, so keep it free of internal state.
 - **Transactional Methods**:
-  - **Read-Only Operations**: All service-level read operations (e.g., `read`, `list`, `count`) MUST be marked with `@Transactional(readOnly = true)`.
-  - **Class-Level Default**: Prefer setting `@Transactional(readOnly = true)` at the class level and overriding it with `@Transactional` on specific write methods (create, update, delete).
+    - **Read-Only Operations**: All service-level read operations (e.g., `read`, `list`, `count`) MUST be marked with
+      `@Transactional(readOnly = true)`.
+    - **Class-Level Default**: Prefer setting `@Transactional(readOnly = true)` at the class level and overriding it
+      with `@Transactional` on specific write methods (create, update, delete).
 
-### Entity Column Constants
+### Feature Architecture (CRUDL framework)
 
-Entities owned by this service expose their table and column names as `public static final String` constants and
-reference them from `@Table` / `@Column` annotations. This keeps a single source of truth for column names and lets
-repositories that build queries programmatically (e.g. via Spring Data Criteria, Sort) refer to them in a refactor-safe
-way.
+Domain features (`category`, `transaction`) are **package-by-feature** and extend a shared generic CRUDL hierarchy in
+`base/crudl/`. The contract is:
 
-- Add a `TABLE` constant (used in `@Table(MyEntity.TABLE)`).
-- Add one constant per persisted column (used in `@Column(COL_NAME)`).
-- Examples: `TransactionEntity`, `CategoryEntity`. `TransactionPagingRepositoryImpl` consumes these via
-  `Criteria.where(TransactionEntity.OWNER_ID)…`.
+- **Entity** — extend `AuditableEntity` (auto `createdAt`/`updatedAt`/`version`) and implement `OwnableEntity<UUID>`
+  (adds `ownerId` for per-user isolation). Identity is assigned by `BaseEntityListener` on insert.
+- **Repository** — extend `OwnableEntityRepository<E, UUID>` (gives `findByIdAndOwnerId`, `findAllByOwnerId`,
+  `existsByIdAndOwnerId`, `countByOwnerId`). Add derived-query methods as needed.
+- **Service** — extend `OwnableEntityService<E, UUID, R, C, U>`. All CRUDL operations are auto-scoped to the current
+  owner; you inherit isolation with no extra code. When a subclass needs the concrete repository/mapper type, **override
+  the getter covariantly** rather than re-declaring a field:
+  ```java
 
-Raw SQL repositories (text-block queries) intentionally keep literal column names in the SQL itself for readability and
-copy-paste-into-`psql` debuggability — entity constants are not interpolated into text blocks.
+@Override
+private TransactionRepository getRepository() { return (TransactionRepository) super.getRepository(); }
+
+```
+- **Controller** — extend `BaseEntityController<…>` **and** `implements <Domain>Api` (the generated interface). Delegate
+  to the `*Internal` helpers (`createInternal`, `readInternal`, …) and **always override `createdURI()`**. Build
+  pagination envelopes with the inherited `toMeta(Page)` helper.
+- **Mapper** — see MapStruct conventions below.
+- **Validator** *(optional)* — implement `BaseEntityValidator<E>` as a `@Component`; it's auto-collected into the
+  service's validator set and run before every save.
+
+### API-First / Contracts
+
+`budget-buddy-contracts` is the **single source of truth**. Controllers implement generated Spring interfaces and all
+request/response DTOs (`Transaction`, `TransactionWrite`, `Problem`, `PaginationMeta`, …) come from the generated
+package — **never hand-write or edit them here**. To change the API surface: update the OpenAPI spec in
+`budget-buddy-contracts` first, publish a new version, bump `budgetBuddyContractsVersion` in `build.gradle.kts`, then
+implement the regenerated interfaces.
+
+- **PUT is full replacement; there is no PATCH.** `updateEntity` overwrites every writable field, nulls included.
+  Partial-update (PATCH) endpoints are intentionally not offered — do not reintroduce them.
+
+### MapStruct Mappers
+
+- Annotate mappers with `@Mapper(config = MapstructConfig.class)` — the shared config sets the Spring component model
+  and constructor injection. Extend `BaseEntityMapper<E, R, C, U, L>`.
+- **Never map onto immutable/identity fields**: `id`, `version`, `createdAt`, `updatedAt`, `ownerId` are `@Mapping(...,
+  ignore = true)` on `toEntity`/`updateEntity` (the base interface already declares these — keep them when overriding).
+- `toModel` / `toModelList` map entity → contract DTO; `toPageResponse(items, meta)` builds the paginated envelope.
+
+### Persistence & Entities
+
+- **Spring Data JDBC, not JPA.** Aggregates are mutable POJOs: `@Table` + `@Id` + `@Column`, with Lombok
+  `@Getter @Setter @NoArgsConstructor @AllArgsConstructor`. Domain column names are string literals in `@Column`. The
+  exception is the shared audit columns, which `AuditableEntity` exposes as constants (`CREATED_AT`, `UPDATED_AT`) so
+  programmatic queries can reference them refactor-safely (e.g. `Sort.by(..., AuditableEntity.CREATED_AT)`).
+- **Optimistic locking** via the `@Version` field inherited from `AuditableEntity`; **auditing**
+  (`createdAt`/`updatedAt`) is automatic — never set these by hand.
+- **Custom type conversion** lives in `CustomJdbcConverters` (e.g. `Currency`, Postgres enums, timestamp→
+  `OffsetDateTime`).
+  Register new converters there.
+
+### Database Migrations (Liquibase)
+
+- Numbered SQL files under `src/main/resources/db/changelog/migrations/` (`NNN-short-description.sql`), registered in
+  `db.changelog-master.yaml`.
+- Each file starts with `--liquibase formatted sql` and a `--changeset <author-email>:<NNN-id>` header.
+- **Every changeset must include a `--rollback`.** **Never edit an already-applied changeset** — add a new one.
+
+### Configuration Properties
+
+Bind external config with a `@Validated @ConfigurationProperties` **record** (constructor binding), e.g.
+`CorsProperties`.
+Profiles: `application.yaml` (shared) + `application-{dev,prod,test}.yaml`. Secrets/issuer come from env vars.
+
+### Null-Safety (JSpecify)
+
+Spring Boot 4 ships JSpecify nullness annotations; this codebase uses `org.jspecify.annotations.@Nullable` /
+`@NonNull`. Treat references as non-null by default and annotate only the genuinely nullable ones (e.g.
+`CategoryEntity.monthlyBudget`). Prefer JSpecify over `jakarta`/Spring nullability annotations.
 
 ### Raw SQL Repositories (`JdbcClient`)
 
@@ -95,33 +186,3 @@ Examples: `TransactionSummaryRepository`, `CategorySummaryRepository`. Conventio
 - **Return value objects**: repositories return small `record`s (e.g. `TransactionSummaryRow`,
   `TransactionTrendBucket`), not API DTOs. The service layer maps to contract types and handles cross-row concerns like
   zero-filling missing buckets.
-
----
-
-## Development Notes
-
-### Testing Locally
-
-1. Run `./gradlew test` for quick all-tests feedback
-2. Use `./gradlew integrationTest --tests "..."` to debug specific integration tests
-3. Leverage `./gradlew bootRun --args='--spring.profiles.active=dev'` to test full app locally
-
-### Common Tasks
-
-- **Run a single test:** `./gradlew test --tests "com.budget.buddy.budget_buddy_api.CategoryServiceTest"`
-- **Run integration test:** `./gradlew integrationTest --tests "com.budget.buddy.budget_buddy_api.CategoryControllerIT"`
-- **Full verification:** `./gradlew check` (runs all tests, linters, SonarQube analysis)
-
-### Available Skills (Claude-specific)
-
-Use these slash commands for common workflows:
-
-| Command | What it does |
-|---|---|
-| `/new-feature <domain>` | Scaffold a full CRUDL domain feature end-to-end |
-| `/add-migration <description>` | Create a numbered Liquibase migration and register it |
-| `/run-tests [scope]` | Run tests and surface failures |
-| `/ship` | Commit all changes and open a PR against `main` |
-| `/javadoc` | Add Javadoc to public/protected API in recently changed files |
-
-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,140 @@
+# Testing Guidelines
+
+How to write tests in this repository. These rules describe the conventions already in use — match them when adding or
+changing tests.
+
+## Source sets & how to run
+
+| Tier            | Location                       | Base class                                       | Runs with                                  |
+|-----------------|--------------------------------|--------------------------------------------------|--------------------------------------------|
+| **Unit**        | `src/test/java/...`            | none (plain JUnit + Mockito)                     | `./gradlew test`                           |
+| **Integration** | `src/integrationTest/java/...` | `BaseIntegrationTest` / `BaseMvcIntegrationTest` | `./gradlew integrationTest` (needs Docker) |
+
+```bash
+./gradlew test                                          # unit
+./gradlew integrationTest                               # integration (Testcontainers → Docker)
+./gradlew test --tests "...TransactionServiceTest"      # single class
+./gradlew check                                         # everything + quality gates
+```
+
+Unit tests mirror the package of the class under test. A unit test class is named `<ClassUnderTest>Test`; an integration
+test class is named `<Feature>IntegrationTest`.
+
+## Naming & structure (both tiers)
+
+- **Test method names:** `should_<Outcome>_When_<Condition>` (the `_When_` half is optional when there's no condition),
+  e.g. `should_CreateTransaction_WithOwnerId`, `should_Return404_When_TransactionBelongsToOtherUser`.
+- **Group with `@Nested`** by operation or scenario (`Create`, `Read`, `Update`, `Delete`, `List`). Keep one concern per
+  nested class.
+- **Use `// Given` / `// When` / `// Then` comments** to structure the body. Tiny tests may collapse `// When & Then`.
+- **AssertJ only** — `assertThat(...)`, `assertThatThrownBy(...)`, `assertThatNoException()`. Never JUnit `Assertions`
+  or Hamcrest.
+- **Attach intent with `.as(...)`** on assertions whose failure wouldn't be self-explanatory:
+
+```java
+assertThat(entity.getOwnerId())
+    .
+
+as("Transaction owner ID should be set to the current user ID")
+    .
+
+isEqualTo(currentUserId);
+```
+
+- **Prefer `record`-style chained assertions** for multi-field checks:
+  `assertThat(updated).returns(5000L, Transaction::getAmount).returns("USD", Transaction::getCurrency)`.
+- **Parameterize** repetitive cases with `@ParameterizedTest` + `@EnumSource` / `@ValueSource` instead of copy-pasting.
+
+## Unit tests
+
+For services, validators, mappers, and other isolated logic.
+
+- `@ExtendWith(MockitoExtension.class)`, collaborators as `@Mock`, the subject via `@InjectMocks` (or built by hand in
+  `@BeforeEach` when constructor args need real values like an `OwnerIdProvider`).
+- **Mock collaborators, not value objects.** Build real DTOs/entities (`new TransactionWrite()`,
+  `new TransactionEntity()`); never mock them.
+- **Assert state first, interactions second.** Prefer asserting the returned value or a captured argument; add
+  `verify(...)` only when the interaction *is* the behavior under test (e.g. "owner id is stamped before save").
+- Capture and assert arguments with `ArgumentCaptor` rather than over-specifying matchers:
+
+```java
+var filterCaptor = ArgumentCaptor.forClass(TransactionFilter.class);
+
+verify(repository).
+
+findAllByFilter(filterCaptor.capture(),any());
+
+assertThat(filterCaptor.getValue().
+
+ownerId()).
+
+isEqualTo(currentUserId);
+```
+
+- For thrown exceptions, assert the **type and message** — and the right type. Domain validation failures throw
+  `ValidationException` (see `TransactionValidator`), not `IllegalArgumentException`:
+
+```java
+assertThatThrownBy(() ->validator.
+
+validate(entity))
+    .
+
+isInstanceOf(ValidationException .class)
+    .
+
+hasMessage("Unknown category with id: "+categoryId);
+```
+
+- Use `verifyNoInteractions(...)` / `verifyNoMoreInteractions(...)` to pin down "and nothing else happened" on the
+  failure path.
+
+## Integration tests
+
+For wiring, security, persistence, and HTTP contract behavior. Real Postgres via Testcontainers (
+`TestcontainersConfig`); each test runs in a rolled-back `@Transactional` so no manual cleanup is needed.
+
+- **Extend the right base:** `BaseMvcIntegrationTest` for HTTP/controller tests (gives `mvc`, `json(...)`,
+  `parseBody(...)`, `createTestUser()`, `jwtForUser(...)`); `BaseIntegrationTest` for repository/persistence tests.
+- **Authenticate with `jwtForUser(subject)`.** Mint distinct subjects via `createTestUser()` so tests are isolated; the
+  provisioning filter auto-creates the local user on first request.
+- **Drive HTTP through `MockMvcTester`** and assert on the result, not by parsing unless you need the body:
+
+```java
+var result = mvc.post().uri("/v1/transactions")
+    .with(jwtForUser(userId))
+    .contentType(MediaType.APPLICATION_JSON)
+    .content(json(new TransactionWrite().categoryId(categoryId)/* ... */))
+    .exchange();
+
+assertThat(result).hasStatus(HttpStatus.CREATED).containsHeader("Location");
+var body = parseBody(result, Transaction.class);
+```
+
+- **Build fixtures through the API**, not by inserting rows directly, so tests exercise the real path (see the
+  `createCategory` / `createTransaction` helpers in `TransactionIntegrationTest`).
+
+## What must be tested
+
+When you add or change an endpoint or domain rule, the change is not done until these exist:
+
+- **Every endpoint:** the happy path **and** `should_Return401_When_NotAuthenticated`.
+- **Every ownable endpoint** (category, transaction, and anything extending `OwnableEntityService`): a cross-user
+  isolation test. Reads/updates/deletes of another user's resource must return **404** (
+  `should_Return404_When_*BelongsToOtherUser`); referencing another user's resource in a write (e.g. a foreign category
+  id) must return **400**. This is the load-bearing security guarantee — never skip it.
+- **Every validator / business rule:** at least one failure-path test asserting the thrown type and message.
+- **List/filter endpoints:** one test per filter dimension plus the empty result, ordering, and pagination-meta cases.
+- **Error mapping:** when you add a `GlobalExceptionHandler` branch, add a handler test asserting the status and
+  `Problem` body shape.
+
+## Anti-patterns to avoid
+
+- **No tautological assertions.** `assertThat(e).returns(e.getId(), BaseEntity::getId)` compares a value to itself and
+  can never fail — assert against an expected literal or a separately-captured value instead.
+- **No wildcard imports** (`import java.util.concurrent.*`). List imports explicitly, consistent with the rest of the
+  codebase.
+- **Close resources.** `ExecutorService` is `AutoCloseable` (Java 21+) — acquire it in try-with-resources rather than a
+  manual `shutdownNow()` in `finally`.
+- **Don't assert on mocked value objects.** A `verify` that a mock returned what you told it to return tests nothing.
+- **Don't reach past the API in integration tests** to set up state the endpoint itself could create.

--- a/src/integrationTest/java/com/budget/buddy/budget_buddy_api/category/CategorySummaryIntegrationTest.java
+++ b/src/integrationTest/java/com/budget/buddy/budget_buddy_api/category/CategorySummaryIntegrationTest.java
@@ -1,7 +1,11 @@
 package com.budget.buddy.budget_buddy_api.category;
 
 import com.budget.buddy.budget_buddy_api.BaseMvcIntegrationTest;
-import com.budget.buddy.budget_buddy_contracts.generated.model.*;
+import com.budget.buddy.budget_buddy_contracts.generated.model.CategorySpendingRow;
+import com.budget.buddy.budget_buddy_contracts.generated.model.CategorySpendingSummary;
+import com.budget.buddy.budget_buddy_contracts.generated.model.CategoryWrite;
+import com.budget.buddy.budget_buddy_contracts.generated.model.TransactionType;
+import com.budget.buddy.budget_buddy_contracts.generated.model.TransactionWrite;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Nested;

--- a/src/integrationTest/java/com/budget/buddy/budget_buddy_api/transaction/TransactionIntegrationTest.java
+++ b/src/integrationTest/java/com/budget/buddy/budget_buddy_api/transaction/TransactionIntegrationTest.java
@@ -1,8 +1,12 @@
 package com.budget.buddy.budget_buddy_api.transaction;
 
 import com.budget.buddy.budget_buddy_api.BaseMvcIntegrationTest;
-import com.budget.buddy.budget_buddy_contracts.generated.model.*;
+import com.budget.buddy.budget_buddy_contracts.generated.model.Category;
+import com.budget.buddy.budget_buddy_contracts.generated.model.CategoryWrite;
+import com.budget.buddy.budget_buddy_contracts.generated.model.PaginatedTransactions;
+import com.budget.buddy.budget_buddy_contracts.generated.model.Transaction;
 import com.budget.buddy.budget_buddy_contracts.generated.model.TransactionType;
+import com.budget.buddy.budget_buddy_contracts.generated.model.TransactionWrite;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/src/integrationTest/java/com/budget/buddy/budget_buddy_api/transaction/TransactionSummaryIntegrationTest.java
+++ b/src/integrationTest/java/com/budget/buddy/budget_buddy_api/transaction/TransactionSummaryIntegrationTest.java
@@ -1,11 +1,17 @@
 package com.budget.buddy.budget_buddy_api.transaction;
 
 import com.budget.buddy.budget_buddy_api.BaseMvcIntegrationTest;
-import com.budget.buddy.budget_buddy_contracts.generated.model.*;
+import com.budget.buddy.budget_buddy_contracts.generated.model.Category;
+import com.budget.buddy.budget_buddy_contracts.generated.model.CategoryWrite;
+import com.budget.buddy.budget_buddy_contracts.generated.model.MonthlySummary;
 import com.budget.buddy.budget_buddy_contracts.generated.model.TransactionType;
+import com.budget.buddy.budget_buddy_contracts.generated.model.TransactionWrite;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import tools.jackson.core.type.TypeReference;
@@ -13,6 +19,7 @@ import tools.jackson.core.type.TypeReference;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static com.budget.buddy.budget_buddy_contracts.generated.model.TransactionType.EXPENSE;
 import static com.budget.buddy.budget_buddy_contracts.generated.model.TransactionType.INCOME;
@@ -195,36 +202,22 @@ class TransactionSummaryIntegrationTest extends BaseMvcIntegrationTest {
       assertThat(result).hasStatus(HttpStatus.UNAUTHORIZED);
     }
 
-    @Test
-    void should_Return400_When_MonthFormatInvalid() {
-      var result = mvc.get().uri("/v1/transactions/summary?month=2026-13&currency=EUR")
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("invalidSummaryRequests")
+    void should_Return400_When_InvalidRequest(String uri) {
+      var result = mvc.get().uri(uri)
           .with(jwtForUser(userId))
           .exchange();
       assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
     }
 
-    @Test
-    void should_Return400_When_CurrencyTooLong() {
-      var result = mvc.get().uri("/v1/transactions/summary?month=2026-03&currency=EURO")
-          .with(jwtForUser(userId))
-          .exchange();
-      assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
-    }
-
-    @Test
-    void should_Return400_When_MonthMissing() {
-      var result = mvc.get().uri("/v1/transactions/summary?currency=EUR")
-          .with(jwtForUser(userId))
-          .exchange();
-      assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
-    }
-
-    @Test
-    void should_Return400_When_CurrencyMissing() {
-      var result = mvc.get().uri("/v1/transactions/summary?month=2026-03")
-          .with(jwtForUser(userId))
-          .exchange();
-      assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    static Stream<Named<String>> invalidSummaryRequests() {
+      return Stream.of(
+          Named.of("Invalid month format", "/v1/transactions/summary?month=2026-13&currency=EUR"),
+          Named.of("Currency too long", "/v1/transactions/summary?month=2026-03&currency=EURO"),
+          Named.of("Missing month", "/v1/transactions/summary?currency=EUR"),
+          Named.of("Missing currency", "/v1/transactions/summary?month=2026-03")
+      );
     }
   }
 
@@ -299,37 +292,22 @@ class TransactionSummaryIntegrationTest extends BaseMvcIntegrationTest {
               tuple(MARCH, 0L));
     }
 
-    @Test
-    void should_Return400_When_FromAfterTo() {
-      var result = mvc.get().uri("/v1/transactions/summary/trend?from=2026-05&to=2026-03&currency=EUR")
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("invalidTrendRequests")
+    void should_Return400_When_InvalidRequest(String uri) {
+      var result = mvc.get().uri(uri)
           .with(jwtForUser(userId))
           .exchange();
       assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
     }
 
-    @Test
-    void should_Return400_When_RangeExceedsCap() {
-      // 25 months (Jan 2024 → Jan 2026 inclusive) > 24-month cap.
-      var result = mvc.get().uri("/v1/transactions/summary/trend?from=2024-01&to=2026-01&currency=EUR")
-          .with(jwtForUser(userId))
-          .exchange();
-      assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
-    }
-
-    @Test
-    void should_Return400_When_FromMalformed() {
-      var result = mvc.get().uri("/v1/transactions/summary/trend?from=2026-13&to=2026-05&currency=EUR")
-          .with(jwtForUser(userId))
-          .exchange();
-      assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
-    }
-
-    @Test
-    void should_Return400_When_FromMissing() {
-      var result = mvc.get().uri("/v1/transactions/summary/trend?to=2026-05&currency=EUR")
-          .with(jwtForUser(userId))
-          .exchange();
-      assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    static Stream<Named<String>> invalidTrendRequests() {
+      return Stream.of(
+          Named.of("From after to", "/v1/transactions/summary/trend?from=2026-05&to=2026-03&currency=EUR"),
+          Named.of("Range exceeds 24-month cap", "/v1/transactions/summary/trend?from=2024-01&to=2026-01&currency=EUR"),
+          Named.of("From malformed", "/v1/transactions/summary/trend?from=2026-13&to=2026-05&currency=EUR"),
+          Named.of("Missing from", "/v1/transactions/summary/trend?to=2026-05&currency=EUR")
+      );
     }
 
     @Test

--- a/src/integrationTest/java/com/budget/buddy/budget_buddy_api/user/UserRepositoryIntegrationTest.java
+++ b/src/integrationTest/java/com/budget/buddy/budget_buddy_api/user/UserRepositoryIntegrationTest.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -70,33 +69,30 @@ class UserRepositoryIntegrationTest extends BaseIntegrationTest {
     var issuer = "test_issuer";
     var threadCount = 16;
 
-    var pool = Executors.newFixedThreadPool(threadCount);
-    var barrier = new CyclicBarrier(threadCount);
-    var tasks = new ArrayList<Callable<UUID>>();
-    for (var i = 0; i < threadCount; i++) {
-      tasks.add(() -> {
-        barrier.await(); // release all threads at once to maximise overlap
-        return userRepository.upsert(UUID.randomUUID(), subject, issuer);
-      });
-    }
+    try (var pool = Executors.newFixedThreadPool(threadCount)) {
+      var barrier = new CyclicBarrier(threadCount);
+      var tasks = new ArrayList<Callable<UUID>>();
+      for (var i = 0; i < threadCount; i++) {
+        tasks.add(() -> {
+          barrier.await(); // release all threads at once to maximise overlap
+          return userRepository.upsert(UUID.randomUUID(), subject, issuer);
+        });
+      }
 
-    // When
-    List<UUID> results = new ArrayList<>();
-    try {
+      // When
+      List<UUID> results = new ArrayList<>();
       var futures = pool.invokeAll(tasks, 30, TimeUnit.SECONDS);
+
       for (Future<UUID> future : futures) {
         results.add(future.get());
       }
-    } finally {
-      pool.shutdownNow();
-    }
 
-    // Then every concurrent caller must resolve to the same, non-null user id.
-    assertThat(results)
-        .as("no concurrent first-login upsert should return a null id")
-        .doesNotContainNull();
-    assertThat(results)
-        .as("all concurrent first-login upserts should resolve to the same user id")
-        .containsOnly(results.getFirst());
+      // Then every concurrent caller must resolve to the same, non-null user id.
+      assertThat(results)
+          .as("no concurrent first-login upsert should return a null id")
+          .doesNotContainNull()
+          .as("all concurrent first-login upserts should resolve to the same user id")
+          .containsOnly(results.getFirst());
+    }
   }
 }

--- a/src/main/java/com/budget/buddy/budget_buddy_api/base/GlobalExceptionHandler.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/base/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.budget.buddy.budget_buddy_api.base;
 
+import com.budget.buddy.budget_buddy_api.base.exception.ValidationException;
 import com.budget.buddy.budget_buddy_api.base.validation.FieldErrorFactory;
 import com.budget.buddy.budget_buddy_contracts.generated.model.FieldError;
 import com.budget.buddy.budget_buddy_contracts.generated.model.Problem;
@@ -211,6 +212,20 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(MissingServletRequestParameterException.class)
   public ResponseEntity<Problem> handleMissingParam(MissingServletRequestParameterException ex, WebRequest request) {
     log.debug("Missing request parameter: {}", ex.getMessage());
+    return problemResponse(HttpStatus.BAD_REQUEST, ex.getMessage(), request);
+  }
+
+  /**
+   * Handles domain validation failures caused by client-supplied data. The message is
+   * author-controlled (see {@link ValidationException}) and surfaced to the client as-is.
+   *
+   * @param ex      the exception
+   * @param request the current web request
+   * @return a {@link ResponseEntity} containing a {@link Problem} detail
+   */
+  @ExceptionHandler(ValidationException.class)
+  public ResponseEntity<Problem> handleValidation(ValidationException ex, WebRequest request) {
+    log.debug("Validation failed: {}", ex.getMessage());
     return problemResponse(HttpStatus.BAD_REQUEST, ex.getMessage(), request);
   }
 

--- a/src/main/java/com/budget/buddy/budget_buddy_api/base/crudl/base/AbstractBaseEntityService.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/base/crudl/base/AbstractBaseEntityService.java
@@ -1,6 +1,8 @@
 package com.budget.buddy.budget_buddy_api.base.crudl.base;
 
 import com.budget.buddy.budget_buddy_api.base.exception.EntityNotFoundException;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -22,9 +24,11 @@ import java.util.List;
 public abstract class AbstractBaseEntityService<E extends BaseEntity<I>, I, R, C, U>
     implements BaseEntityService<I, R, C, U> {
 
-  private static final String ENTITY_NOT_FOUND_MESSAGE = "Entity not found with id: %s";
+  protected static final String ENTITY_NOT_FOUND_MESSAGE = "Entity not found with id: %s";
 
+  @Getter(AccessLevel.PROTECTED)
   private final BaseEntityRepository<E, I> repository;
+  @Getter(AccessLevel.PROTECTED)
   private final BaseEntityMapper<E, R, C, U, ?> mapper;
   private final Iterable<BaseEntityValidator<E>> validators;
 

--- a/src/main/java/com/budget/buddy/budget_buddy_api/base/crudl/base/BaseEntityController.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/base/crudl/base/BaseEntityController.java
@@ -1,6 +1,7 @@
 package com.budget.buddy.budget_buddy_api.base.crudl.base;
 
 import com.budget.buddy.budget_buddy_contracts.generated.model.PaginationMeta;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -95,15 +96,23 @@ public abstract class BaseEntityController<I, R, C, U, L> {
    */
   public ResponseEntity<L> listInternal(Pageable pageable) {
     var items = service.list(pageable);
-
-    var meta = new PaginationMeta();
-    meta.setPage(items.getNumber());
-    meta.setSize(items.getSize());
-    meta.setTotal(items.getTotalElements());
-
-    var response = mapper.toPageResponse(items.getContent(), meta);
-
+    var response = mapper.toPageResponse(items.getContent(), toMeta(items));
     return ResponseEntity.ok(response);
+  }
+
+  /**
+   * Builds the {@link PaginationMeta} envelope from a {@link Page}, mirroring its page number,
+   * size, and total element count.
+   *
+   * @param page the page to describe
+   * @return the populated pagination metadata
+   */
+  protected static PaginationMeta toMeta(Page<?> page) {
+    var meta = new PaginationMeta();
+    meta.setPage(page.getNumber());
+    meta.setSize(page.getSize());
+    meta.setTotal(page.getTotalElements());
+    return meta;
   }
 
   /**

--- a/src/main/java/com/budget/buddy/budget_buddy_api/base/crudl/ownable/OwnableEntityService.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/base/crudl/ownable/OwnableEntityService.java
@@ -26,12 +26,6 @@ import org.springframework.data.domain.Pageable;
 public class OwnableEntityService<E extends OwnableEntity<I>, I, R, C, U>
     extends AbstractBaseEntityService<E, I, R, C, U> {
 
-  private static final String ENTITY_NOT_FOUND_MESSAGE = "Entity not found with id: %s";
-
-  @Getter(AccessLevel.PROTECTED)
-  private final OwnableEntityRepository<E, I> repository;
-  @Getter(AccessLevel.PROTECTED)
-  private final BaseEntityMapper<E, R, C, U, ?> mapper;
   @Getter(AccessLevel.PROTECTED)
   private final OwnerIdProvider<I> ownerIdProvider;
 
@@ -42,37 +36,40 @@ public class OwnableEntityService<E extends OwnableEntity<I>, I, R, C, U>
       OwnerIdProvider<I> ownerIdProvider
   ) {
     super(repository, mapper, entityValidators);
-    this.repository = repository;
-    this.mapper = mapper;
     this.ownerIdProvider = ownerIdProvider;
   }
 
   @Override
+  protected OwnableEntityRepository<E, I> getRepository() {
+    return (OwnableEntityRepository<E, I>) super.getRepository();
+  }
+
+  @Override
   protected Page<E> listInternal(Pageable pageRequest) {
-    return repository.findAllByOwnerId(ownerIdProvider.get(), pageRequest);
+    return getRepository().findAllByOwnerId(ownerIdProvider.get(), pageRequest);
   }
 
   @Override
   protected E readInternal(I id) {
-    return repository.findByIdAndOwnerId(id, ownerIdProvider.get())
+    return getRepository().findByIdAndOwnerId(id, ownerIdProvider.get())
         .orElseThrow(() -> new EntityNotFoundException(ENTITY_NOT_FOUND_MESSAGE.formatted(id)));
   }
 
   @Override
   protected boolean existsByIdInternal(I id) {
-    return repository.existsByIdAndOwnerId(id, ownerIdProvider.get());
+    return getRepository().existsByIdAndOwnerId(id, ownerIdProvider.get());
   }
 
   @Override
   protected E createInternal(C createRequest) {
-    E entity = mapper.toEntity(createRequest);
+    E entity = getMapper().toEntity(createRequest);
     entity.setOwnerId(ownerIdProvider.get());
     validate(entity);
-    return repository.save(entity);
+    return getRepository().save(entity);
   }
 
   @Override
   protected long countInternal() {
-    return repository.countByOwnerId(ownerIdProvider.get());
+    return getRepository().countByOwnerId(ownerIdProvider.get());
   }
 }

--- a/src/main/java/com/budget/buddy/budget_buddy_api/base/exception/ValidationException.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/base/exception/ValidationException.java
@@ -1,0 +1,17 @@
+package com.budget.buddy.budget_buddy_api.base.exception;
+
+/**
+ * Signals that a domain validation rule was violated by client-supplied data.
+ *
+ * <p>Distinct from {@link IllegalArgumentException} (which conventionally indicates a
+ * programming error): a {@code ValidationException} is an expected outcome of bad input
+ * and is mapped to {@code 400 Bad Request}. The message is intended to be surfaced to the
+ * client, so it must not leak internal state.
+ */
+public class ValidationException extends RuntimeException {
+
+  public ValidationException(String message) {
+    super(message);
+  }
+
+}

--- a/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionController.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionController.java
@@ -2,8 +2,11 @@ package com.budget.buddy.budget_buddy_api.transaction;
 
 import com.budget.buddy.budget_buddy_api.base.crudl.base.BaseEntityController;
 import com.budget.buddy.budget_buddy_contracts.generated.api.TransactionsApi;
-import com.budget.buddy.budget_buddy_contracts.generated.model.*;
+import com.budget.buddy.budget_buddy_contracts.generated.model.MonthlySummary;
+import com.budget.buddy.budget_buddy_contracts.generated.model.PaginatedTransactions;
+import com.budget.buddy.budget_buddy_contracts.generated.model.Transaction;
 import com.budget.buddy.budget_buddy_contracts.generated.model.TransactionType;
+import com.budget.buddy.budget_buddy_contracts.generated.model.TransactionWrite;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -72,13 +75,7 @@ public class TransactionController
 
   ResponseEntity<PaginatedTransactions> listTransactions(TransactionFilter filter, Pageable pageable) {
     var items = service.list(filter, pageable);
-
-    var meta = new PaginationMeta();
-    meta.setPage(items.getNumber());
-    meta.setSize(items.getSize());
-    meta.setTotal(items.getTotalElements());
-
-    return ResponseEntity.ok(mapper.toPageResponse(items.getContent(), meta));
+    return ResponseEntity.ok(mapper.toPageResponse(items.getContent(), toMeta(items)));
   }
 
   @Override

--- a/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionSummaryRepository.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionSummaryRepository.java
@@ -23,7 +23,7 @@ public class TransactionSummaryRepository {
   private static final String RANGE_START = "rangeStart";
   private static final String RANGE_END = "rangeEnd";
 
-  private static final RowMapper<TransactionSummaryRow> TRANSACTION_SUMMARY_ROW_ROW_MAPPER = (rs, _) ->
+  private static final RowMapper<TransactionSummaryRow> SUMMARY_ROW_MAPPER = (rs, _) ->
       new TransactionSummaryRow(
           rs.getLong("income"),
           rs.getLong("expense"),
@@ -35,7 +35,7 @@ public class TransactionSummaryRepository {
   private static final RowMapper<TransactionTrendBucket> TREND_BUCKET_ROW_MAPPER = (rs, rowNum) ->
       new TransactionTrendBucket(
           YearMonth.from(rs.getDate("month_start").toLocalDate()),
-          TRANSACTION_SUMMARY_ROW_ROW_MAPPER.mapRow(rs, rowNum)
+          SUMMARY_ROW_MAPPER.mapRow(rs, rowNum)
       );
 
   private static final String SUMMARY_SQL = """
@@ -83,7 +83,7 @@ public class TransactionSummaryRepository {
         .param(RANGE_START, rangeStart)
         .param(RANGE_END, rangeEnd)
         .param(CURRENCY, currency)
-        .query(TRANSACTION_SUMMARY_ROW_ROW_MAPPER)
+        .query(SUMMARY_ROW_MAPPER)
         .single();
   }
 

--- a/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionSummaryService.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionSummaryService.java
@@ -1,6 +1,7 @@
 package com.budget.buddy.budget_buddy_api.transaction;
 
 import com.budget.buddy.budget_buddy_api.base.crudl.ownable.OwnerIdProvider;
+import com.budget.buddy.budget_buddy_api.base.exception.ValidationException;
 import com.budget.buddy.budget_buddy_contracts.generated.model.MonthlySummary;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -37,7 +38,7 @@ public class TransactionSummaryService {
    *
    * @param month    calendar month formatted {@code YYYY-MM}
    * @param currency ISO 4217 currency code; only matching transactions contribute to totals
-   * @throws IllegalArgumentException if {@code month} is not a valid {@code YYYY-MM} value
+   * @throws ValidationException if {@code month} is not a valid {@code YYYY-MM} value
    */
   public MonthlySummary getSummary(String month, String currency) {
     var yearMonth = parseMonth(month, "month");
@@ -54,18 +55,18 @@ public class TransactionSummaryService {
    * @param fromMonth first calendar month, inclusive ({@code YYYY-MM})
    * @param toMonth   last calendar month, inclusive ({@code YYYY-MM})
    * @param currency  ISO 4217 currency code
-   * @throws IllegalArgumentException if either bound is malformed, {@code fromMonth} is after
-   *                                  {@code toMonth}, or the span exceeds {@link #MAX_RANGE_MONTHS}
+   * @throws ValidationException if either bound is malformed, {@code fromMonth} is after
+   *                             {@code toMonth}, or the span exceeds {@link #MAX_RANGE_MONTHS}
    */
   public List<MonthlySummary> getTrend(String fromMonth, String toMonth, String currency) {
     var from = parseMonth(fromMonth, "from");
     var to = parseMonth(toMonth, "to");
     if (from.isAfter(to)) {
-      throw new IllegalArgumentException("'from' must be on or before 'to'");
+      throw new ValidationException("'from' must be on or before 'to'");
     }
     long span = ChronoUnit.MONTHS.between(from, to) + 1;
     if (span > MAX_RANGE_MONTHS) {
-      throw new IllegalArgumentException(
+      throw new ValidationException(
           "Range too wide: max " + MAX_RANGE_MONTHS + " months, requested " + span);
     }
 
@@ -96,9 +97,9 @@ public class TransactionSummaryService {
   private static YearMonth parseMonth(String value, String paramName) {
     try {
       return YearMonth.parse(value);
-    } catch (DateTimeParseException e) {
-      throw new IllegalArgumentException(
-          "Invalid '" + paramName + "' format: '" + value + "', expected YYYY-MM", e);
+    } catch (DateTimeParseException _) {
+      throw new ValidationException(
+          "Invalid '" + paramName + "' format: '" + value + "', expected YYYY-MM");
     }
   }
 

--- a/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionValidator.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionValidator.java
@@ -1,11 +1,13 @@
 package com.budget.buddy.budget_buddy_api.transaction;
 
 import com.budget.buddy.budget_buddy_api.base.crudl.base.BaseEntityValidator;
+import com.budget.buddy.budget_buddy_api.base.exception.ValidationException;
 import com.budget.buddy.budget_buddy_api.category.CategoryService;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+
+import java.util.UUID;
 
 @Slf4j
 @Component
@@ -21,11 +23,11 @@ public class TransactionValidator implements BaseEntityValidator<TransactionEnti
 
   private void validateCategory(UUID categoryId) {
     if (categoryId == null) {
-      throw new IllegalArgumentException("Category ID must be set");
+      throw new ValidationException("Category ID must be set");
     }
 
     if (!categoryService.existsById(categoryId)) {
-      throw new IllegalArgumentException("Unknown category with id: " + categoryId);
+      throw new ValidationException("Unknown category with id: " + categoryId);
     }
   }
 }

--- a/src/main/resources/sonar-project.properties
+++ b/src/main/resources/sonar-project.properties
@@ -1,1 +1,0 @@
-sonar.issue.ignore.multicriteria.e1.ruleKey=java:S119

--- a/src/test/java/com/budget/buddy/budget_buddy_api/base/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/budget/buddy/budget_buddy_api/base/GlobalExceptionHandlerTest.java
@@ -1,5 +1,6 @@
 package com.budget.buddy.budget_buddy_api.base;
 
+import com.budget.buddy.budget_buddy_api.base.exception.ValidationException;
 import com.budget.buddy.budget_buddy_contracts.generated.model.FieldError;
 import com.budget.buddy.budget_buddy_contracts.generated.model.Problem;
 import jakarta.servlet.http.HttpServletRequest;
@@ -383,6 +384,32 @@ class GlobalExceptionHandlerTest {
       var problem = response.getBody();
       assertThat(problem)
           .returns(HttpStatus.BAD_REQUEST.getReasonPhrase(), Problem::getTitle)
+          .returns(400, Problem::getStatus);
+    }
+  }
+
+  @Nested
+  @DisplayName("ValidationException Handler")
+  class ValidationExceptionTests {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "Category ID must be set",
+        "Unknown category with id: 123"
+    })
+    @DisplayName("should handle ValidationException as 400 with the author-controlled message")
+    void shouldHandleValidation(String message) {
+      // Given
+      var exception = new ValidationException(message);
+
+      // When
+      var response = handler.handleValidation(exception, webRequest);
+
+      // Then
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+      assertThat(response.getBody()).isNotNull();
+      assertThat(response.getBody())
+          .returns(message, Problem::getDetail)
           .returns(400, Problem::getStatus);
     }
   }

--- a/src/test/java/com/budget/buddy/budget_buddy_api/base/crudl/base/AbstractBaseEntityServiceTest.java
+++ b/src/test/java/com/budget/buddy/budget_buddy_api/base/crudl/base/AbstractBaseEntityServiceTest.java
@@ -13,8 +13,13 @@ import org.springframework.data.domain.PageRequest;
 import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AbstractBaseEntityServiceTest {
@@ -109,7 +114,8 @@ class AbstractBaseEntityServiceTest {
       // Then
       assertThat(actual).isEqualTo(expected);
       assertThat(existingEntity)
-          .returns(existingEntity.getId(), BaseEntity::getId);
+          .as("Update must preserve the entity id")
+          .returns(id, BaseEntity::getId);
       verify(repository).findById(id);
       verify(mapper).updateEntity(updateRequest, existingEntity);
       verify(repository).save(existingEntity);

--- a/src/test/java/com/budget/buddy/budget_buddy_api/base/crudl/ownable/OwnableEntityServiceTest.java
+++ b/src/test/java/com/budget/buddy/budget_buddy_api/base/crudl/ownable/OwnableEntityServiceTest.java
@@ -164,8 +164,7 @@ class OwnableEntityServiceTest {
   class ExistsByIdInternalTests {
 
     @Test
-    @DisplayName("should return repository result")
-    void shouldReturnRepositoryResult() {
+    void should_ReturnRepositoryResult() {
       // Given
       var id = "123";
       when(repository.existsByIdAndOwnerId(id, ownerId)).thenReturn(true);
@@ -184,8 +183,7 @@ class OwnableEntityServiceTest {
   class CreateInternalTests {
 
     @Test
-    @DisplayName("should map to entity, set owner ID, and save")
-    void shouldCreateEntity() {
+    void should_MapToEntity_SetOwnerId_AndSave() {
       // Given
       var createRequest = new Object();
       var entity = new DummyOwnableEntity();
@@ -207,8 +205,7 @@ class OwnableEntityServiceTest {
   class CountInternalTests {
 
     @Test
-    @DisplayName("should return count by owner ID")
-    void shouldReturnCount() {
+    void should_ReturnCountByOwnerId() {
       // Given
       when(repository.countByOwnerId(ownerId)).thenReturn(5L);
 

--- a/src/test/java/com/budget/buddy/budget_buddy_api/security/oidc/OidcUserProvisioningFilterTest.java
+++ b/src/test/java/com/budget/buddy/budget_buddy_api/security/oidc/OidcUserProvisioningFilterTest.java
@@ -24,7 +24,9 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 @DisplayName("OidcUserProvisioningFilter Unit Tests")
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/com/budget/buddy/budget_buddy_api/transaction/TransactionValidatorTest.java
+++ b/src/test/java/com/budget/buddy/budget_buddy_api/transaction/TransactionValidatorTest.java
@@ -1,18 +1,20 @@
 package com.budget.buddy.budget_buddy_api.transaction;
 
-import static org.assertj.core.api.Assertions.assertThatNoException;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.when;
-
+import com.budget.buddy.budget_buddy_api.base.exception.ValidationException;
 import com.budget.buddy.budget_buddy_api.category.CategoryService;
-import java.util.Currency;
-import java.util.UUID;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Currency;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class TransactionValidatorTest {
@@ -54,8 +56,8 @@ class TransactionValidatorTest {
 
       // When & Then
       assertThatThrownBy(() -> validator.validate(entity))
-          .as("Should throw IllegalArgumentException when Category ID is null")
-          .isInstanceOf(IllegalArgumentException.class)
+          .as("Should throw ValidationException when Category ID is null")
+          .isInstanceOf(ValidationException.class)
           .hasMessage("Category ID must be set");
     }
 
@@ -68,8 +70,8 @@ class TransactionValidatorTest {
 
       // When & Then
       assertThatThrownBy(() -> validator.validate(entity))
-          .as("Should throw IllegalArgumentException when the specified category does not exist")
-          .isInstanceOf(IllegalArgumentException.class)
+          .as("Should throw ValidationException when the specified category does not exist")
+          .isInstanceOf(ValidationException.class)
           .hasMessage("Unknown category with id: " + categoryId);
     }
   }


### PR DESCRIPTION
## Summary

Pure refactoring / code-quality pass — **no behavior change**. Tightens the codebase against the agent guides (`AGENTS.md` / `TESTING.md`) and clears SonarQube findings. All error responses keep their existing HTTP status codes (verified by the integration suite).

## Production code
- **`ValidationException`** for client-input / domain-rule failures, so they're distinct from programming errors. Mapped to `400` in `GlobalExceptionHandler`. `TransactionValidator` and `TransactionSummaryService` now throw it instead of `IllegalArgumentException` (both already surfaced as 400).
- **CRUDL dedup:** dropped the shadowed `repository`/`mapper` fields in `OwnableEntityService` in favour of covariant getter overrides; extracted the shared `toMeta(Page)` pagination helper onto `BaseEntityController`.
- Renamed the over-long row-mapper constant in `TransactionSummaryRepository`.

## Tests
- **SonarQube S5976:** collapsed the duplicated `400`-response cases in `TransactionSummaryIntegrationTest` into `@ParameterizedTest`, matching the existing `@MethodSource` + `Named` pattern already used in `CategorySummaryIntegrationTest`.
- Removed a tautological assertion (`returns(e.getId(), …)` comparing a value to itself), expanded wildcard imports, and fixed an `ExecutorService` resource leak (try-with-resources) — all `TESTING.md` anti-patterns.
- Aligned inconsistent test method names with the `should_<Outcome>` convention.

## Docs & tooling
- Added `TESTING.md` (test-writing guide) and `CLAUDE.md` (symlink → `AGENTS.md`); corrected and expanded `AGENTS.md`.
- Removed the unused `sonar-project.properties`.

## Verification
`./gradlew check` green — unit + integration (Testcontainers) + JaCoCo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)