### PR TITLE
chore: add .editorconfig for cross-editor formatting consistency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,66 @@
+# EditorConfig — single source of truth for formatting across editors and tools.
+# IntelliJ IDEA reads this natively and applies it over the project code style.
+# Docs: https://editorconfig.org  |  IntelliJ ij_* props: https://www.jetbrains.com/help/idea/editorconfig.html
+root = true
+
+# ── Defaults for every file ────────────────────────────────────────────────
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+max_line_length = 140
+
+# ── Java ───────────────────────────────────────────────────────────────────
+[*.java]
+indent_size = 2
+continuation_indent_size = 4
+
+# Imports: no wildcards, no blank lines between groups (matches this codebase).
+ij_java_use_single_class_import = true
+ij_java_class_count_to_use_import_on_demand = 999
+ij_java_names_count_to_use_import_on_demand = 999
+ij_java_packages_to_use_import_on_demand = none
+ij_java_imports_layout = $*, |, *
+ij_java_insert_inner_class_imports = false
+
+# Spacing / wrapping niceties IntelliJ applies on reformat.
+ij_java_keep_blank_lines_in_code = 1
+ij_java_blank_lines_after_class_header = 0
+ij_java_align_multiline_parameters = false
+ij_java_method_parameters_wrap = on_every_item
+ij_java_call_parameters_wrap = normal
+ij_java_doc_keep_empty_lines = true
+
+# ── Kotlin (Gradle DSL) ──────────────────────────────────────────────────--
+[*.{kt,kts}]
+indent_size = 2
+continuation_indent_size = 4
+ij_kotlin_name_count_to_use_star_import = 999
+ij_kotlin_name_count_to_use_star_import_for_members = 999
+
+# ── Config & data files ──────────────────────────────────────────────────--
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.{xml,sql,json,properties,toml}]
+indent_size = 2
+
+# ── Markdown ─────────────────────────────────────────────────────────────--
+# Keep trailing whitespace: two trailing spaces are a hard line break in Markdown.
+[*.md]
+trim_trailing_whitespace = false
+
+# ── Gradle wrapper & generated files ─────────────────────────────────────--
+[gradlew.bat]
+end_of_line = crlf
+
+[gradle/wrapper/*.properties]
+insert_final_newline = false
+
+# ── ASCII-art banner: preserve exact whitespace ──────────────────────────--
+[banner.txt]
+trim_trailing_whitespace = false
+insert_final_newline = false


### PR DESCRIPTION
## Why

Formatting was only defined by `.idea/codeStyles` (IntelliJ-only, and `.idea/` isn't version-controlled here), so anything that isn't IntelliJ — VS Code, CI, AI agents/tools — had no shared style. That's how the 2-vs-4-space indentation drift slipped into the Gradle build earlier. `.editorconfig` is the cross-editor standard and IntelliJ applies it *over* the project scheme, making it a single source of truth.

## What

Add a root `.editorconfig` encoding the **existing** conventions in this repo (verified against the code, nothing new imposed):

- 2-space indent, 4-space continuation; LF; UTF-8; final newline; trim trailing whitespace.
- Java: no wildcard imports, no blank lines between import groups (matches current style), sensible wrapping defaults via `ij_java_*`.
- Kotlin DSL, YAML, SQL, XML, JSON, properties, TOML: 2-space.
- `max_line_length = 140` as a soft guide (no reflow today — reformat-on-save isn't enabled).

Carve-outs preserve intent: Markdown keeps trailing whitespace (hard line breaks), `gradlew.bat` stays CRLF (consistent with `.gitattributes`), and `banner.txt` / `gradle-wrapper.properties` keep their exact bytes.

## Notes

- No code is reformatted in this PR; it only configures editors going forward.
- Complements the existing `.gitattributes` (git owns line endings; `.editorconfig` mirrors the same intent for editors).
