### PR TITLE
chore: exclude Liquibase migrations from SonarCloud analysis

### DIFF
--- a/.sonarlint/connectedMode.json
+++ b/.sonarlint/connectedMode.json
@@ -1,0 +1,5 @@
+{
+  "sonarCloudOrganization": "budget-buddy-org",
+  "projectKey": "budget-buddy-org_budget-buddy-api",
+  "region": "EU"
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,8 @@
+# SonarCloud analysis configuration (read by Automatic Analysis).
+#
+# Liquibase migrations are PostgreSQL, but SonarQube only ships an Oracle
+# PL/SQL analyzer — there is no PostgreSQL dialect. Running it over these
+# files produces only false positives (e.g. "use VARCHAR2 instead of VARCHAR",
+# treating `--rollback` Liquibase directives as commented-out code, and
+# flagging intentional one-time data-wipe DELETEs). Exclude them from analysis.
+sonar.exclusions=src/main/resources/db/changelog/migrations/**


### PR DESCRIPTION
## Summary

Adds a `sonar-project.properties` that excludes the Liquibase migration directory from SonarCloud analysis.

SonarQube only ships an **Oracle PL/SQL** analyzer — there is no PostgreSQL dialect. Running it over our Postgres/Liquibase migrations produces **only false positives**:

- `plsql:VarcharUsageCheck` — "use `VARCHAR2` instead of `VARCHAR`" (Oracle-only type) ×8
- `plsql:S125` — `--rollback ...` Liquibase directives misread as commented-out code ×2
- `plsql:DeleteOrUpdateWithoutWhereCheck` — intentional one-time data-wipe `DELETE`s flagged as missing `WHERE` (BLOCKER) ×3

## Effect

Clears **13 false-positive issues** (3 of them BLOCKER) and prevents the same noise on every future migration. SonarCloud Automatic Analysis will auto-close them as "removed" on the next scan.

Done in the same review pass: the 4 `java:S2187` ("add some tests to this class") false positives on `@Nested` JUnit 5 test classes were resolved as **False Positive** directly in SonarCloud — those files must stay in analysis, so an exclusion would be wrong there.

Net result: **0 real issues**; all 17 open findings were false positives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
