### PR TITLE
ci: harden pnpm install with --ignore-scripts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,7 +92,7 @@ jobs:
           node-version: "24"
           cache: "pnpm"
 
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Run semantic-release
         env:

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -23,7 +23,7 @@ jobs:
           node-version: 24
           cache: pnpm
 
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Lint commit messages
         if: github.actor != 'dependabot[bot]'


### PR DESCRIPTION
## Summary

Adds `--ignore-scripts` to both `pnpm install` steps in CI, resolving two SonarCloud **Security Hotspots** ("Omitting `--ignore-scripts` can lead to the execution of shell scripts").

- `.github/workflows/ci.yaml` (release job → `semantic-release`)
- `.github/workflows/commitlint.yaml` (`commitlint`)

## Why

When `pnpm install` runs, dependency lifecycle scripts (`preinstall`/`postinstall`) execute automatically. A compromised package could run arbitrary code in CI — where `GITHUB_TOKEN` is in scope. `--ignore-scripts` is standard supply-chain hardening for CI installs.

## Why it's safe here

- The project's `package.json` defines **no scripts** (`"scripts": {}`), so nothing the build needs is skipped.
- Both jobs only invoke pure-JS CLIs via `pnpm exec`, which require the installed modules to be present — not their lifecycle scripts.
- `--frozen-lockfile` is retained, so installs stay pinned and reproducible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
