### PR TITLE
ci: add workflow_dispatch trigger to Docker Publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -3,6 +3,12 @@ name: Docker Publish
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch or tag to build and publish'
+        required: true
+        default: 'main'
 
 jobs:
   docker-build:
@@ -21,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || inputs.ref }}
 
       - name: Set up JDK 25
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
@@ -96,7 +102,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || inputs.ref }}
 
       - name: Log in to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4


### PR DESCRIPTION
## Why

The Docker Publish workflow could only be triggered by a GitHub release event. There was no way to test image builds on a feature branch or re-publish a tag after an infra change (e.g. a Trivy policy update) without creating a new release.

## What changed

- Added a `workflow_dispatch` trigger with a single `ref` input (branch or tag, defaults to `main`)
- Both checkout steps now resolve the ref as `github.event.release.tag_name || inputs.ref` — the release path is unchanged; the manual trigger falls through to the user-supplied value

## How to verify

1. Go to **Actions → Docker Publish → Run workflow** — a `ref` input field should appear
2. Enter a branch name (e.g. `main`) or a tag and trigger the run
3. Confirm the workflow checks out the expected ref and proceeds through the build/publish/sign steps normally
4. Trigger a release to confirm the existing automated path still works as before