### PR TITLE
fix: resolve Sonar issues and improve test coverage

### DIFF
--- a/src/main/java/com/budget/buddy/budget_buddy_api/base/validation/FieldErrorFactory.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/base/validation/FieldErrorFactory.java
@@ -22,7 +22,8 @@ public final class FieldErrorFactory {
 
   public static FieldError from(org.springframework.validation.FieldError fieldError) {
     Objects.requireNonNull(fieldError);
-    var message = Objects.requireNonNullElse(fieldError.getDefaultMessage(), "Invalid value");
+    var defaultMessage = fieldError.getDefaultMessage();
+    var message = defaultMessage != null ? defaultMessage : "Invalid value";
 
     return new FieldError()
         .field(fieldError.getField())

--- a/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionValidator.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionValidator.java
@@ -5,6 +5,7 @@ import com.budget.buddy.budget_buddy_api.base.exception.ValidationException;
 import com.budget.buddy.budget_buddy_api.category.CategoryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Component;
 
 import java.util.UUID;
@@ -21,7 +22,7 @@ public class TransactionValidator implements BaseEntityValidator<TransactionEnti
     validateCategory(entity.getCategoryId());
   }
 
-  private void validateCategory(UUID categoryId) {
+  private void validateCategory(@Nullable UUID categoryId) {
     if (categoryId == null) {
       throw new ValidationException("Category ID must be set");
     }

--- a/src/test/java/com/budget/buddy/budget_buddy_api/base/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/budget/buddy/budget_buddy_api/base/GlobalExceptionHandlerTest.java
@@ -26,15 +26,22 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.exc.MismatchedInputException;
+import tools.jackson.databind.exc.UnrecognizedPropertyException;
 
 import java.net.URI;
+import java.time.format.DateTimeParseException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.NoSuchElementException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON;
@@ -65,8 +72,8 @@ class GlobalExceptionHandlerTest {
 
   @BeforeEach
   void init() {
-    when(httpServletRequest.getRequestURI()).thenReturn(REQUEST_URI);
-    when(webRequest.getRequest()).thenReturn(httpServletRequest);
+    lenient().when(httpServletRequest.getRequestURI()).thenReturn(REQUEST_URI);
+    lenient().when(webRequest.getRequest()).thenReturn(httpServletRequest);
     handler = new GlobalExceptionHandler();
   }
 
@@ -386,6 +393,98 @@ class GlobalExceptionHandlerTest {
           .returns(HttpStatus.BAD_REQUEST.getReasonPhrase(), Problem::getTitle)
           .returns(400, Problem::getStatus);
     }
+
+    @Test
+    @DisplayName("should return field error when cause is UnrecognizedPropertyException")
+    void shouldHandleUnrecognizedProperty() {
+      // Given
+      var cause = mock(UnrecognizedPropertyException.class);
+      when(cause.getPropertyName()).thenReturn("unknownField");
+      var exception = mock(HttpMessageNotReadableException.class);
+      when(exception.getCause()).thenReturn(cause);
+
+      // When
+      var response = handler.handleNotReadable(exception, webRequest);
+
+      // Then
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+      assertThat(response.getBody()).isNotNull();
+      assertThat(response.getBody().getErrors())
+          .hasSize(1)
+          .first()
+          .satisfies(e -> {
+            assertThat(e.getField()).isEqualTo("unknownField");
+            assertThat(e.getMessage()).isEqualTo("unknown field");
+          });
+    }
+
+    @Test
+    @DisplayName("should return field error with json path when cause is MismatchedInputException with path")
+    void shouldHandleMismatchedInputWithPath() {
+      // Given
+      var ref1 = new JacksonException.Reference(String.class, "amount");
+      var ref2 = new JacksonException.Reference(String.class, 0);
+      var cause = mock(MismatchedInputException.class);
+      when(cause.getPath()).thenReturn(List.of(ref1, ref2));
+      var exception = mock(HttpMessageNotReadableException.class);
+      when(exception.getCause()).thenReturn(cause);
+
+      // When
+      var response = handler.handleNotReadable(exception, webRequest);
+
+      // Then
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+      assertThat(response.getBody()).isNotNull();
+      assertThat(response.getBody().getErrors())
+          .hasSize(1)
+          .first()
+          .satisfies(e -> {
+            assertThat(e.getField()).isEqualTo("amount.[0]");
+            assertThat(e.getMessage()).isEqualTo("invalid value");
+          });
+    }
+
+    @Test
+    @DisplayName("should return null path when cause is MismatchedInputException with empty path")
+    void shouldHandleMismatchedInputWithEmptyPath() {
+      // Given
+      var cause = mock(MismatchedInputException.class);
+      when(cause.getPath()).thenReturn(Collections.emptyList());
+      var exception = mock(HttpMessageNotReadableException.class);
+      when(exception.getCause()).thenReturn(cause);
+
+      // When
+      var response = handler.handleNotReadable(exception, webRequest);
+
+      // Then
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+      assertThat(response.getBody()).isNotNull();
+      assertThat(response.getBody().getErrors())
+          .hasSize(1)
+          .first()
+          .satisfies(e -> assertThat(e.getField()).isEqualTo("null"));
+    }
+
+    @Test
+    @DisplayName("should return null path when cause is MismatchedInputException with null path")
+    void shouldHandleMismatchedInputWithNullPath() {
+      // Given
+      var cause = mock(MismatchedInputException.class);
+      when(cause.getPath()).thenReturn(null);
+      var exception = mock(HttpMessageNotReadableException.class);
+      when(exception.getCause()).thenReturn(cause);
+
+      // When
+      var response = handler.handleNotReadable(exception, webRequest);
+
+      // Then
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+      assertThat(response.getBody()).isNotNull();
+      assertThat(response.getBody().getErrors())
+          .hasSize(1)
+          .first()
+          .satisfies(e -> assertThat(e.getField()).isEqualTo("null"));
+    }
   }
 
   @Nested
@@ -468,6 +567,49 @@ class GlobalExceptionHandlerTest {
           .returns(HttpStatus.NOT_IMPLEMENTED.getReasonPhrase(), Problem::getTitle)
           .returns("Operation not supported", Problem::getDetail)
           .returns(501, Problem::getStatus);
+    }
+  }
+
+  @Nested
+  @DisplayName("DateTimeParseException Handler")
+  class DateTimeParseExceptionTests {
+
+    @Test
+    @DisplayName("should handle DateTimeParseException as 400 with the parsed string in the detail")
+    void shouldHandleDateTimeParse() {
+      // Given
+      var exception = new DateTimeParseException("Text 'invalid' could not be parsed", "invalid", 0);
+
+      // When
+      var response = handler.handleDateTimeParse(exception, webRequest);
+
+      // Then
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+      assertThat(response.getBody()).isNotNull();
+      assertThat(response.getBody())
+          .returns(400, Problem::getStatus)
+          .returns("Invalid date or time value: invalid", Problem::getDetail);
+    }
+  }
+
+  @Nested
+  @DisplayName("Request URI resolution")
+  class RequestUriTests {
+
+    @Test
+    @DisplayName("should return empty string when request is not a ServletWebRequest")
+    void shouldReturnEmptyUriForNonServletRequest() {
+      // Given — plain WebRequest mock, not a ServletWebRequest
+      var plainRequest = mock(WebRequest.class);
+      var exception = new NoSuchElementException("not found");
+
+      // When
+      var response = handler.handleNotFound(exception, plainRequest);
+
+      // Then
+      assertThat(response.getBody()).isNotNull();
+      assertThat(response.getBody().getInstance())
+          .isEqualTo(URI.create(""));
     }
   }
 

--- a/src/test/java/com/budget/buddy/budget_buddy_api/base/mapper/CurrencyMapperTest.java
+++ b/src/test/java/com/budget/buddy/budget_buddy_api/base/mapper/CurrencyMapperTest.java
@@ -1,0 +1,42 @@
+package com.budget.buddy.budget_buddy_api.base.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Currency;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("CurrencyMapper Unit Tests")
+class CurrencyMapperTest {
+
+  private final CurrencyMapper mapper = new CurrencyMapperImpl();
+
+  @Nested
+  class ToCurrency {
+
+    @Test
+    void should_ReturnNull_When_CodeIsNull() {
+      assertThat(mapper.toCurrency(null)).isNull();
+    }
+
+    @Test
+    void should_ReturnCurrency_When_CodeIsValid() {
+      assertThat(mapper.toCurrency("EUR")).isEqualTo(Currency.getInstance("EUR"));
+    }
+  }
+
+  @Nested
+  class ToCurrencyCode {
+
+    @Test
+    void should_ReturnNull_When_CurrencyIsNull() {
+      assertThat(mapper.toCurrencyCode(null)).isNull();
+    }
+
+    @Test
+    void should_ReturnCode_When_CurrencyIsNotNull() {
+      assertThat(mapper.toCurrencyCode(Currency.getInstance("USD"))).isEqualTo("USD");
+    }
+  }
+}

--- a/src/test/java/com/budget/buddy/budget_buddy_api/base/validation/FieldErrorFactoryTest.java
+++ b/src/test/java/com/budget/buddy/budget_buddy_api/base/validation/FieldErrorFactoryTest.java
@@ -91,6 +91,23 @@ class FieldErrorFactoryTest {
     }
 
     @Test
+    @DisplayName("should fall back to 'Invalid value' when defaultMessage is null")
+    void shouldFallBackToDefaultMessageWhenNull() {
+      // Given — Spring allows null defaultMessage via the 3-arg constructor
+      var springFieldError = new org.springframework.validation.FieldError(
+          "user", "email", null
+      );
+
+      // When
+      FieldError result = FieldErrorFactory.from(springFieldError);
+
+      // Then
+      assertThat(result)
+          .returns("email", FieldError::getField)
+          .returns("Invalid value", FieldError::getMessage);
+    }
+
+    @Test
     @DisplayName("should throw NullPointerException when fieldError is null")
     void shouldThrowNpe() {
       assertThatThrownBy(() -> FieldErrorFactory.from((org.springframework.validation.FieldError) null))

--- a/src/test/java/com/budget/buddy/budget_buddy_api/security/oidc/OidcOwnerIdProviderTest.java
+++ b/src/test/java/com/budget/buddy/budget_buddy_api/security/oidc/OidcOwnerIdProviderTest.java
@@ -1,0 +1,69 @@
+package com.budget.buddy.budget_buddy_api.security.oidc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.server.resource.InvalidBearerTokenException;
+
+@DisplayName("OidcOwnerIdProvider Unit Tests")
+class OidcOwnerIdProviderTest {
+
+  private final OidcOwnerIdProvider provider = new OidcOwnerIdProvider();
+
+  @AfterEach
+  void clearSecurityContext() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Nested
+  class Get {
+
+    @Test
+    void should_ReturnLocalUserId_When_LocalUserAuthenticationIsPresent() {
+      // Given
+      var userId = UUID.randomUUID();
+      var auth = mock(LocalUserAuthentication.class);
+      org.mockito.Mockito.when(auth.getLocalUserId()).thenReturn(userId);
+      SecurityContextHolder.getContext().setAuthentication(auth);
+
+      // When
+      var result = provider.get();
+
+      // Then
+      assertThat(result).isEqualTo(userId);
+    }
+
+    @Test
+    void should_ThrowInvalidBearerTokenException_When_AuthenticationIsNotLocalUser() {
+      // Given
+      var auth = new AnonymousAuthenticationToken(
+          "key", "anonymousUser", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS"));
+      SecurityContextHolder.getContext().setAuthentication(auth);
+
+      // When / Then
+      assertThatThrownBy(provider::get)
+          .isInstanceOf(InvalidBearerTokenException.class)
+          .hasMessage("Current user is not authenticated.");
+    }
+
+    @Test
+    void should_ThrowInvalidBearerTokenException_When_NoAuthenticationInContext() {
+      // Given — security context has no authentication (null)
+      SecurityContextHolder.clearContext();
+
+      // When / Then
+      assertThatThrownBy(provider::get)
+          .isInstanceOf(InvalidBearerTokenException.class)
+          .hasMessage("Current user is not authenticated.");
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- **FieldErrorFactory**: replace `Objects.requireNonNullElse` with a ternary expression so Sonar can track the null-safety guarantee through the expression (fixes `java:S4449`)
- **TransactionValidator**: annotate `categoryId` parameter as `@Nullable` to make the null guard intentional rather than flagged as always-false (fixes `java:S2583`)
- **Test coverage**: add missing tests for `GlobalExceptionHandler` (`UnrecognizedPropertyException`/`MismatchedInputException` branches, `DateTimeParseException` handler, non-`ServletWebRequest` URI fallback), plus new `CurrencyMapperTest` and `OidcOwnerIdProviderTest`

## Test plan

- [ ] `./gradlew test` passes (all unit tests green)
- [ ] No new open Sonar issues after merge

🤖 Generated with [Claude Code](https://claude.ai/claude-code)