### PR TITLE
feat: establish logging standards and MDC request correlation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,24 @@ endpoint).
 - **Request URI**: The `instance` field should contain the current request URI, retrieved using `ServletWebRequest` in
   `GlobalExceptionHandler`.
 
+### Logging
+
+- **Always use `@Slf4j`**: Declare loggers via Lombok `@Slf4j` on the class — never use `LoggerFactory.getLogger()` manually.
+- **Log levels**:
+  - `ERROR` — unexpected failures that need immediate attention; always include the exception as a second argument (`log.error("...", ex)`).
+  - `WARN` — recoverable issues the system can handle but that need visibility: auth failures, access-denied, data integrity violations.
+  - `INFO` — significant business events: entity created (`id=…`), entity deleted (`id=…`). Visible in all environments.
+  - `DEBUG` — request flow detail: reads, updates, list/count calls, validation steps. Off in production by default.
+  - `TRACE` — fine-grained internals; reserved for framework-level diagnostics.
+- **No PII in logs**: Never log OIDC subjects, raw JWTs, or personal data at any level. Internal UUIDs (our own generated IDs) are safe to log. Use DEBUG for anything that might be user-identifying.
+- **No full-object logging**: Never pass a full request/response/entity to a log statement — log only IDs and counts to avoid inadvertently leaking user data.
+- **MDC correlation**: Every request carries two MDC keys populated automatically:
+  - `requestId` — set by `RequestCorrelationFilter` (propagated from `X-Request-ID` header or generated); echoed back in the response header.
+  - `userId` — set by `OidcUserProvisioningFilter` after JWT authentication resolves to a local user UUID.
+  - Both keys appear in every log line. Do not clear or overwrite them; let the filters manage the lifecycle.
+- **Dev vs prod output**: Dev uses Spring Boot's default human-readable console pattern extended with `[requestId] [userId]`. Prod emits structured JSON (ECS format via `logging.structured.format.console: ecs`) — all MDC keys appear as top-level fields automatically.
+- **Parameterized messages**: Always use SLF4J placeholders (`log.debug("id={}", id)`) — never string concatenation.
+
 ### Security & OIDC
 
 - **Stateless resource server**: The API validates JWTs from an external OIDC provider. No sessions, no server-side

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,19 @@ endpoint).
    ```bash
    ./gradlew test integrationTest
    ```
-2. **No open Sonar issues** — if the `MCP_DOCKER` MCP server is available, query it directly:
+2. **100% code coverage on changed files** — every new or modified production class must be fully covered (lines + branches). Check via Sonar on the open PR:
+   ```
+   Tool: mcp__MCP_DOCKER__search_files_by_coverage
+   Args: { "projectKey": "budget-buddy-org_budget-buddy-api", "pullRequest": "<PR number>", "maxCoverage": 100 }
+   ```
+   For any file below 100%, get the exact uncovered lines:
+   ```
+   Tool: mcp__MCP_DOCKER__get_file_coverage_details
+   Args: { "key": "<file key from above>", "pullRequest": "<PR number>" }
+   ```
+   Add tests until all files report 100% line and branch coverage. Generated code (MapStruct mappers, Lombok) and `package-info.java` are excluded automatically via `sonar.coverage.exclusions`.
+
+3. **No open Sonar issues** — if the `MCP_DOCKER` MCP server is available, query it directly:
    ```
    Tool: mcp__MCP_DOCKER__search_sonar_issues_in_projects
    Args: { "projects": ["budget-buddy-org_budget-buddy-api"], "issueStatuses": ["OPEN"] }

--- a/src/main/java/com/budget/buddy/budget_buddy_api/base/GlobalExceptionHandler.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/base/GlobalExceptionHandler.java
@@ -5,9 +5,8 @@ import com.budget.buddy.budget_buddy_api.base.validation.FieldErrorFactory;
 import com.budget.buddy.budget_buddy_contracts.generated.model.FieldError;
 import com.budget.buddy.budget_buddy_contracts.generated.model.Problem;
 import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -34,10 +33,9 @@ import java.util.NoSuchElementException;
 /**
  * Global exception handler for the application. Converts various exceptions into standardized {@link Problem} responses.
  */
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-
-  private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
   private static final String RESOURCE_NOT_FOUND = "Resource not found";
   private static final String ACCESS_DENIED = "Access denied";
@@ -90,6 +88,7 @@ public class GlobalExceptionHandler {
         .map(FieldErrorFactory::from)
         .toList();
 
+    log.debug("Validation failed: {} field error(s)", errors.size());
     var problem = new Problem().errors(errors);
     return buildProblemResponse(problem, HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.getReasonPhrase(), "One or more fields are invalid", request);
   }
@@ -108,6 +107,7 @@ public class GlobalExceptionHandler {
         .map(FieldErrorFactory::from)
         .toList();
 
+    log.debug("Constraint violations: {} error(s)", errors.size());
     var problem = new Problem().errors(errors);
     return buildProblemResponse(problem, HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.getReasonPhrase(), "Constraint violations", request);
   }

--- a/src/main/java/com/budget/buddy/budget_buddy_api/base/crudl/base/AbstractBaseEntityService.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/base/crudl/base/AbstractBaseEntityService.java
@@ -55,53 +55,46 @@ public abstract class AbstractBaseEntityService<E extends BaseEntity<ID>, ID, C,
   @Transactional
   @Override
   public R create(C createRequest) {
-    log.debug("Create entity: {}", createRequest);
     E savedEntity = createInternal(createRequest);
-    log.debug("Saved entity: {}", savedEntity);
+    log.info("Created entity: id={}", savedEntity.getId());
     return mapper.toModel(savedEntity);
   }
 
   @Override
   public R read(ID id) {
-    log.debug("Read entity by id: {}", id);
-    E entity = readInternal(id);
-    return mapper.toModel(entity);
+    log.debug("Read entity: id={}", id);
+    return mapper.toModel(readInternal(id));
   }
 
   @Transactional
   @Override
   public R update(ID id, U updateRequest) {
-    log.debug("Update entity by id: {}", id);
-    E updatedEntity = updateInternal(id, updateRequest);
-    log.debug("Updated entity: {}", updatedEntity);
-    return mapper.toModel(updatedEntity);
+    log.debug("Update entity: id={}", id);
+    return mapper.toModel(updateInternal(id, updateRequest));
   }
 
   @Transactional
   @Override
   public void delete(ID id) {
-    log.debug("Delete entity by id: {}", id);
     deleteInternal(id);
-    log.debug("Successfully deleted entity with id: {}", id);
+    log.info("Deleted entity: id={}", id);
   }
 
   @Override
   public List<R> list() {
-    log.debug("List all entities");
-    List<E> entities = listInternal();
-    log.debug("Found {} entities", entities.size());
-    return mapper.toModelList(entities);
+    log.debug("List entities");
+    return mapper.toModelList(listInternal());
   }
 
   @Override
   public L list(Pageable pageable) {
-    log.debug("List all entities with pageRequest: {}", pageable);
+    log.debug("List entities: page={}, size={}", pageable.getPageNumber(), pageable.getPageSize());
     return mapper.toPage(listInternal(pageable));
   }
 
   @Override
   public long count() {
-    log.debug("Count all entities");
+    log.debug("Count entities");
     return countInternal();
   }
 

--- a/src/main/java/com/budget/buddy/budget_buddy_api/base/logging/RequestCorrelationFilter.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/base/logging/RequestCorrelationFilter.java
@@ -1,0 +1,51 @@
+package com.budget.buddy.budget_buddy_api.base.logging;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Propagates or generates a request correlation ID and makes it available in the
+ * MDC under {@value #REQUEST_ID_MDC_KEY} for the duration of the request.
+ *
+ * <p>If the caller supplies an {@code X-Request-ID} header it is reused;
+ * otherwise a new UUID is generated. The same value is echoed back in the
+ * response header so clients can correlate their own logs.
+ */
+@Slf4j
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class RequestCorrelationFilter extends OncePerRequestFilter {
+
+  public static final String REQUEST_ID_HEADER = "X-Request-ID";
+  public static final String REQUEST_ID_MDC_KEY = "requestId";
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      FilterChain chain
+  ) throws ServletException, IOException {
+    var inbound = request.getHeader(REQUEST_ID_HEADER);
+    var requestId = (inbound != null && !inbound.isBlank()) ? inbound : UUID.randomUUID().toString();
+
+    MDC.put(REQUEST_ID_MDC_KEY, requestId);
+    response.setHeader(REQUEST_ID_HEADER, requestId);
+    log.debug("{} {}", request.getMethod(), request.getRequestURI());
+
+    try {
+      chain.doFilter(request, response);
+    } finally {
+      MDC.remove(REQUEST_ID_MDC_KEY);
+    }
+  }
+}

--- a/src/main/java/com/budget/buddy/budget_buddy_api/base/logging/package-info.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/base/logging/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package com.budget.buddy.budget_buddy_api.base.logging;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/com/budget/buddy/budget_buddy_api/security/oidc/OidcUserProvisioningFilter.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/security/oidc/OidcUserProvisioningFilter.java
@@ -5,15 +5,15 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.InvalidBearerTokenException;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.web.filter.OncePerRequestFilter;
-
-import java.io.IOException;
 
 /**
  * Upgrades the post-authentication {@link JwtAuthenticationToken} to a
@@ -31,6 +31,8 @@ import java.io.IOException;
 public class OidcUserProvisioningFilter extends OncePerRequestFilter {
 
   private final UserService userService;
+
+  private static final String USER_ID_MDC_KEY = "userId";
 
   @Override
   protected void doFilterInternal(
@@ -51,10 +53,16 @@ public class OidcUserProvisioningFilter extends OncePerRequestFilter {
         throw new InvalidBearerTokenException("JWT must contain both 'sub' and 'iss' claims");
       }
 
+      log.debug("Upgrading JWT authentication: issuer={}", oidcIssuer);
       var localUserId = userService.findOrCreateByOidcSubject(oidcSubject, oidcIssuer.toString());
+      MDC.put(USER_ID_MDC_KEY, localUserId.toString());
       context.setAuthentication(new LocalUserAuthentication(jwt, jwtAuth.getAuthorities(), localUserId));
     }
 
-    filterChain.doFilter(request, response);
+    try {
+      filterChain.doFilter(request, response);
+    } finally {
+      MDC.remove(USER_ID_MDC_KEY);
+    }
   }
 }

--- a/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionValidator.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/transaction/TransactionValidator.java
@@ -27,6 +27,7 @@ public class TransactionValidator implements BaseEntityValidator<TransactionEnti
       throw new ValidationException("Category ID must be set");
     }
 
+    log.debug("Validating transaction category: id={}", categoryId);
     if (!categoryService.existsById(categoryId)) {
       throw new ValidationException("Unknown category with id: " + categoryId);
     }

--- a/src/main/java/com/budget/buddy/budget_buddy_api/user/UserService.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/user/UserService.java
@@ -39,7 +39,7 @@ public class UserService {
    */
   @Cacheable(value = CacheConfig.LOCAL_USER_IDS, key = "#oidcIssuer + '|' + #oidcSubject", unless = "#result == null")
   public UUID findOrCreateByOidcSubject(String oidcSubject, String oidcIssuer) {
-    log.debug("Resolving local user for OIDC issuer: {}", oidcIssuer);
+    log.debug("Cache miss: resolving local user from DB for issuer={}", oidcIssuer);
     return repository.upsert(idGenerator.get(), oidcSubject, oidcIssuer);
   }
 }

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -36,5 +36,8 @@ springdoc:
     enabled: false
 
 logging:
+  structured:
+    format:
+      console: ecs
   level:
     root: INFO

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -19,6 +19,10 @@ spring:
 server:
   port: ${SERVER_PORT:8080}
 
+logging:
+  pattern:
+    correlation: "[%X{requestId:-}] [%X{userId:-}] "
+
 security:
   cors:
     allowed-origin-patterns: [ ]

--- a/src/test/java/com/budget/buddy/budget_buddy_api/base/crudl/base/AbstractBaseEntityServiceTest.java
+++ b/src/test/java/com/budget/buddy/budget_buddy_api/base/crudl/base/AbstractBaseEntityServiceTest.java
@@ -233,4 +233,37 @@ class AbstractBaseEntityServiceTest {
     }
 
   }
+
+  @Nested
+  class ExistsTests {
+
+    @Test
+    void should_ReturnTrue_When_EntityExists() {
+      // Given
+      var id = "existingId";
+      when(repository.existsById(id)).thenReturn(true);
+
+      // When
+      var actual = service.existsById(id);
+
+      // Then
+      assertThat(actual).isTrue();
+      verify(repository).existsById(id);
+    }
+
+    @Test
+    void should_ReturnFalse_When_EntityDoesNotExist() {
+      // Given
+      var id = "missingId";
+      when(repository.existsById(id)).thenReturn(false);
+
+      // When
+      var actual = service.existsById(id);
+
+      // Then
+      assertThat(actual).isFalse();
+      verify(repository).existsById(id);
+    }
+
+  }
 }

--- a/src/test/java/com/budget/buddy/budget_buddy_api/base/logging/RequestCorrelationFilterTest.java
+++ b/src/test/java/com/budget/buddy/budget_buddy_api/base/logging/RequestCorrelationFilterTest.java
@@ -1,0 +1,114 @@
+package com.budget.buddy.budget_buddy_api.base.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.MDC;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+@ExtendWith(MockitoExtension.class)
+class RequestCorrelationFilterTest {
+
+  @Mock
+  private FilterChain filterChain;
+
+  private RequestCorrelationFilter filter;
+  private MockHttpServletRequest request;
+  private MockHttpServletResponse response;
+
+  @BeforeEach
+  void setUp() {
+    filter = new RequestCorrelationFilter();
+    request = new MockHttpServletRequest();
+    response = new MockHttpServletResponse();
+    MDC.clear();
+  }
+
+  @Nested
+  class WhenNoRequestIdHeader {
+
+    @Test
+    void should_GenerateUuid_And_SetResponseHeader() throws ServletException, IOException {
+      filter.doFilterInternal(request, response, filterChain);
+
+      assertThat(response.getHeader(RequestCorrelationFilter.REQUEST_ID_HEADER))
+          .isNotBlank()
+          .matches("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}");
+      verify(filterChain).doFilter(request, response);
+    }
+  }
+
+  @Nested
+  class WhenBlankRequestIdHeader {
+
+    @Test
+    void should_GenerateUuid_When_HeaderIsEmpty() throws ServletException, IOException {
+      request.addHeader(RequestCorrelationFilter.REQUEST_ID_HEADER, "");
+
+      filter.doFilterInternal(request, response, filterChain);
+
+      assertThat(response.getHeader(RequestCorrelationFilter.REQUEST_ID_HEADER))
+          .isNotBlank();
+      verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void should_GenerateUuid_When_HeaderIsWhitespace() throws ServletException, IOException {
+      request.addHeader(RequestCorrelationFilter.REQUEST_ID_HEADER, "   ");
+
+      filter.doFilterInternal(request, response, filterChain);
+
+      assertThat(response.getHeader(RequestCorrelationFilter.REQUEST_ID_HEADER))
+          .isNotBlank();
+      verify(filterChain).doFilter(request, response);
+    }
+  }
+
+  @Nested
+  class WhenValidRequestIdHeader {
+
+    @Test
+    void should_PropagateExistingRequestId() throws ServletException, IOException {
+      var existingId = "my-request-id-123";
+      request.addHeader(RequestCorrelationFilter.REQUEST_ID_HEADER, existingId);
+
+      filter.doFilterInternal(request, response, filterChain);
+
+      assertThat(response.getHeader(RequestCorrelationFilter.REQUEST_ID_HEADER))
+          .isEqualTo(existingId);
+      verify(filterChain).doFilter(request, response);
+    }
+  }
+
+  @Nested
+  class MdcLifecycle {
+
+    @Test
+    void should_PopulateMdc_During_Request() throws ServletException, IOException {
+      var capturedRequestId = new String[1];
+
+      filter.doFilterInternal(request, response, (req, res) -> {
+        capturedRequestId[0] = MDC.get(RequestCorrelationFilter.REQUEST_ID_MDC_KEY);
+      });
+
+      assertThat(capturedRequestId[0]).isNotBlank();
+    }
+
+    @Test
+    void should_ClearMdc_After_Request() throws ServletException, IOException {
+      filter.doFilterInternal(request, response, filterChain);
+
+      assertThat(MDC.get(RequestCorrelationFilter.REQUEST_ID_MDC_KEY)).isNull();
+    }
+  }
+}


### PR DESCRIPTION
## Why

The app had no observability in production. Create and delete operations were only logged at DEBUG (silent with `root=INFO`), full request/entity objects were passed to log statements (PII risk), the OIDC auth filter had a logger declared but never used it, and there was no way to correlate log lines from the same request. This PR establishes consistent standards and fills those gaps.

## What changed

- **`RequestCorrelationFilter` (new)** — runs at `HIGHEST_PRECEDENCE` before all other filters. Propagates `X-Request-ID` from the incoming request or generates a UUID, puts it in MDC as `requestId`, and echoes it in the response header. All log lines for a request now carry the same ID.

- **`OidcUserProvisioningFilter`** — adds a `log.debug` for the JWT→local-user upgrade and puts the resolved local user UUID into MDC as `userId` (cleared in `finally`). Every authenticated request now has both `requestId` and `userId` in every log line.

- **`AbstractBaseEntityService`** — promotes create and delete to `INFO id=…` so mutations are visible in production without enabling DEBUG. Removes full-object logging of request bodies and saved entities (was a PII risk). Trims redundant pre/post log pairs for update/list.

- **`GlobalExceptionHandler`** — replaces the manual `LoggerFactory.getLogger()` with `@Slf4j`; adds missing debug logs to the two validation handlers that had none.

- **`TransactionValidator`** — adds a debug log for category validation (the `@Slf4j` annotation was present but unused).

- **`UserService`** — clarifies the debug message to indicate it fires only on cache misses (DB lookups), not on every authenticated request.

- **`application.yaml`** — adds `logging.pattern.correlation: "[%X{requestId:-}] [%X{userId:-}] "` so both MDC keys appear in every log line across all profiles.

- **`application-prod.yaml`** — adds `logging.structured.format.console: ecs` for machine-readable ECS JSON output; MDC keys appear as top-level fields automatically.

- **`AGENTS.md`** — adds a **Logging** section documenting all standards: `@Slf4j` always, level guidelines, no-PII rule, no-full-object rule, MDC lifecycle, and dev vs prod output format.

## How to verify

1. Run with the dev profile and make any API call — confirm `[<uuid>] [<userId>]` appears in every log line for that request.
2. Call `GET /v1/categories` (or any list endpoint) — confirm a `DEBUG List entities` line appears.
3. Create a category — confirm an `INFO Created entity: id=<uuid>` line appears (visible without enabling DEBUG).
4. Delete a category — confirm `INFO Deleted entity: id=<uuid>`.
5. Submit an invalid request body — confirm `DEBUG Validation failed: N field error(s)`.
6. Run `./gradlew test integrationTest` — all tests pass.
7. With the prod profile (`logging.structured.format.console: ecs`), log output is JSON with `requestId` and `userId` as top-level fields.

## Notes

`logging.pattern.correlation` is ignored when structured logging is active (prod), so there's no conflict between the base config and prod config. The `userId` MDC key holds our internal UUID, not the OIDC subject — no PII concern.