### PR TITLE
feat: implement DELETE /v1/users/me account deletion

### DIFF
--- a/src/integrationTest/java/com/budget/buddy/budget_buddy_api/user/me/MeDeleteCurrentUserIntegrationTest.java
+++ b/src/integrationTest/java/com/budget/buddy/budget_buddy_api/user/me/MeDeleteCurrentUserIntegrationTest.java
@@ -1,0 +1,126 @@
+package com.budget.buddy.budget_buddy_api.user.me;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.budget.buddy.budget_buddy_api.BaseMvcIntegrationTest;
+import com.budget.buddy.budget_buddy_contracts.generated.model.Category;
+import com.budget.buddy.budget_buddy_contracts.generated.model.CategoryWrite;
+import com.budget.buddy.budget_buddy_contracts.generated.model.PaginatedCategories;
+import com.budget.buddy.budget_buddy_contracts.generated.model.PaginatedTransactions;
+import com.budget.buddy.budget_buddy_contracts.generated.model.TransactionType;
+import com.budget.buddy.budget_buddy_contracts.generated.model.TransactionWrite;
+import com.budget.buddy.budget_buddy_contracts.generated.model.UserPreferences;
+import com.budget.buddy.budget_buddy_contracts.generated.model.UserPreferencesWrite;
+import java.time.LocalDate;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+class MeDeleteCurrentUserIntegrationTest extends BaseMvcIntegrationTest {
+
+  private static final String ME_URI = "/v1/users/me";
+  private static final String PREFERENCES_URI = "/v1/users/me/preferences";
+
+  private String userId;
+  private String otherUserId;
+
+  private UUID createCategory(String ownerId, String name) throws Exception {
+    var result = mvc.post().uri("/v1/categories")
+        .with(jwtForUser(ownerId))
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(json(new CategoryWrite().name(name)))
+        .exchange();
+    return parseBody(result, Category.class).getId();
+  }
+
+  private void createTransaction(String ownerId, UUID categoryId) {
+    mvc.post().uri("/v1/transactions")
+        .with(jwtForUser(ownerId))
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(json(new TransactionWrite()
+            .categoryId(categoryId)
+            .amount(500L)
+            .type(TransactionType.EXPENSE)
+            .currency("EUR")
+            .date(LocalDate.of(2026, 1, 1))))
+        .exchange();
+  }
+
+  private void storePreferences(String ownerId) {
+    mvc.put().uri(PREFERENCES_URI)
+        .with(jwtForUser(ownerId))
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(json(new UserPreferencesWrite().language("en").currency("EUR").timezone("Europe/Tallinn")))
+        .exchange();
+  }
+
+  private long categoryCount(String ownerId) throws Exception {
+    var result = mvc.get().uri("/v1/categories").with(jwtForUser(ownerId)).exchange();
+    return parseBody(result, PaginatedCategories.class).getMeta().getTotal();
+  }
+
+  private long transactionCount(String ownerId) throws Exception {
+    var result = mvc.get().uri("/v1/transactions").with(jwtForUser(ownerId)).exchange();
+    return parseBody(result, PaginatedTransactions.class).getMeta().getTotal();
+  }
+
+  @BeforeEach
+  void setUp() throws Exception {
+    userId = createTestUser();
+    otherUserId = createTestUser();
+
+    var categoryId = createCategory(userId, "Groceries");
+    createTransaction(userId, categoryId);
+    storePreferences(userId);
+
+    var otherCategoryId = createCategory(otherUserId, "Travel");
+    createTransaction(otherUserId, otherCategoryId);
+    storePreferences(otherUserId);
+  }
+
+  @Nested
+  class DeleteCurrentUser {
+
+    @Test
+    void should_Return204() {
+      var result = mvc.delete().uri(ME_URI).with(jwtForUser(userId)).exchange();
+
+      assertThat(result).hasStatus(HttpStatus.NO_CONTENT);
+    }
+
+    @Test
+    void should_CascadeDeleteAllUserData() throws Exception {
+      mvc.delete().uri(ME_URI).with(jwtForUser(userId)).exchange();
+
+      // The deleted user's JWT re-provisions a fresh account — expect empty data
+      assertThat(transactionCount(userId)).as("transactions are gone").isZero();
+      assertThat(categoryCount(userId)).as("categories are gone").isZero();
+      var prefs = parseBody(
+          mvc.get().uri(PREFERENCES_URI).with(jwtForUser(userId)).exchange(),
+          UserPreferences.class);
+      assertThat(prefs.getCurrency()).as("preferences are gone").isNull();
+    }
+
+    @Test
+    void should_LeaveOtherUsersDataIntact() throws Exception {
+      mvc.delete().uri(ME_URI).with(jwtForUser(userId)).exchange();
+
+      assertThat(transactionCount(otherUserId)).as("other user's transactions untouched").isEqualTo(1);
+      assertThat(categoryCount(otherUserId)).as("other user's categories untouched").isEqualTo(1);
+      var prefs = parseBody(
+          mvc.get().uri(PREFERENCES_URI).with(jwtForUser(otherUserId)).exchange(),
+          UserPreferences.class);
+      assertThat(prefs.getCurrency()).as("other user's preferences untouched").isEqualTo("EUR");
+    }
+
+    @Test
+    void should_Return401_When_NotAuthenticated() {
+      var result = mvc.delete().uri(ME_URI).exchange();
+
+      assertThat(result).hasStatus(HttpStatus.UNAUTHORIZED);
+    }
+  }
+}

--- a/src/main/java/com/budget/buddy/budget_buddy_api/user/UserRepository.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/user/UserRepository.java
@@ -42,4 +42,6 @@ public interface UserRepository extends Repository<UserEntity, UUID> {
       @Param("oidcIssuer") String oidcIssuer
   );
 
+  void deleteById(UUID id);
+
 }

--- a/src/main/java/com/budget/buddy/budget_buddy_api/user/UserService.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/user/UserService.java
@@ -1,10 +1,13 @@
 package com.budget.buddy.budget_buddy_api.user;
 
 import com.budget.buddy.budget_buddy_api.base.config.CacheConfig;
+import com.budget.buddy.budget_buddy_api.base.crudl.ownable.OwnerIdProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 import java.util.function.Supplier;
@@ -26,6 +29,7 @@ public class UserService {
 
   private final UserRepository repository;
   private final Supplier<UUID> idGenerator;
+  private final OwnerIdProvider<UUID> ownerIdProvider;
 
   /**
    * Finds or creates a local user for the given OIDC subject.
@@ -41,5 +45,13 @@ public class UserService {
   public UUID findOrCreateByOidcSubject(String oidcSubject, String oidcIssuer) {
     log.debug("Cache miss: resolving local user from DB for issuer={}", oidcIssuer);
     return repository.upsert(idGenerator.get(), oidcSubject, oidcIssuer);
+  }
+
+  @Transactional
+  @CacheEvict(value = CacheConfig.LOCAL_USER_IDS, allEntries = true)
+  public void deleteCurrentUser() {
+    var userId = ownerIdProvider.get();
+    log.info("Deleting user account id={}", userId);
+    repository.deleteById(userId);
   }
 }

--- a/src/main/java/com/budget/buddy/budget_buddy_api/user/me/MeController.java
+++ b/src/main/java/com/budget/buddy/budget_buddy_api/user/me/MeController.java
@@ -1,5 +1,6 @@
 package com.budget.buddy.budget_buddy_api.user.me;
 
+import com.budget.buddy.budget_buddy_api.user.UserService;
 import com.budget.buddy.budget_buddy_api.user.me.preferences.UserPreferencesService;
 import com.budget.buddy.budget_buddy_contracts.generated.api.UsersApi;
 import com.budget.buddy.budget_buddy_contracts.generated.model.ClientSettings;
@@ -25,6 +26,7 @@ public class MeController implements UsersApi {
 
   private final UserDataDeletionService dataDeletionService;
   private final UserPreferencesService preferencesService;
+  private final UserService userService;
 
   @Override
   public ResponseEntity<Me> getCurrentUser() {
@@ -33,7 +35,8 @@ public class MeController implements UsersApi {
 
   @Override
   public ResponseEntity<Void> deleteCurrentUser() {
-    throw notImplemented("deleteCurrentUser");
+    userService.deleteCurrentUser();
+    return ResponseEntity.noContent().build();
   }
 
   @Override

--- a/src/test/java/com/budget/buddy/budget_buddy_api/user/UserServiceTest.java
+++ b/src/test/java/com/budget/buddy/budget_buddy_api/user/UserServiceTest.java
@@ -1,5 +1,6 @@
 package com.budget.buddy.budget_buddy_api.user;
 
+import com.budget.buddy.budget_buddy_api.base.crudl.ownable.OwnerIdProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -10,6 +11,7 @@ import java.util.UUID;
 import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -21,8 +23,21 @@ class UserServiceTest {
   @Mock
   private Supplier<UUID> idGenerator;
 
+  @Mock
+  private OwnerIdProvider<UUID> ownerIdProvider;
+
   @InjectMocks
   private UserService userService;
+
+  @Test
+  void deleteCurrentUser_Should_DeleteByResolvedOwnerId() {
+    var userId = UUID.randomUUID();
+    when(ownerIdProvider.get()).thenReturn(userId);
+
+    userService.deleteCurrentUser();
+
+    verify(userRepository).deleteById(userId);
+  }
 
   @Test
   void upsert_Should_DelegateToRepository() {

--- a/src/test/java/com/budget/buddy/budget_buddy_api/user/me/MeControllerTest.java
+++ b/src/test/java/com/budget/buddy/budget_buddy_api/user/me/MeControllerTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.budget.buddy.budget_buddy_api.user.UserService;
 import com.budget.buddy.budget_buddy_api.user.me.preferences.UserPreferencesService;
 import com.budget.buddy.budget_buddy_contracts.generated.model.ClientSettingsWrite;
 import com.budget.buddy.budget_buddy_contracts.generated.model.UserPreferences;
@@ -26,12 +27,14 @@ class MeControllerTest {
   private UserDataDeletionService deletionService;
   @Mock
   private UserPreferencesService preferencesService;
+  @Mock
+  private UserService userService;
 
   private MeController controller;
 
   @BeforeEach
   void setUp() {
-    controller = new MeController(deletionService, preferencesService);
+    controller = new MeController(deletionService, preferencesService, userService);
   }
 
   @Nested
@@ -42,13 +45,6 @@ class MeControllerTest {
       assertThatThrownBy(() -> controller.getCurrentUser())
           .isInstanceOf(UnsupportedOperationException.class)
           .hasMessageContaining("getCurrentUser");
-    }
-
-    @Test
-    void deleteCurrentUser_ShouldThrowUnsupportedOperationException() {
-      assertThatThrownBy(() -> controller.deleteCurrentUser())
-          .isInstanceOf(UnsupportedOperationException.class)
-          .hasMessageContaining("deleteCurrentUser");
     }
 
     @Test
@@ -78,6 +74,18 @@ class MeControllerTest {
       assertThatThrownBy(() -> controller.deleteCurrentUserClientSettings("app"))
           .isInstanceOf(UnsupportedOperationException.class)
           .hasMessageContaining("deleteCurrentUserClientSettings");
+    }
+  }
+
+  @Nested
+  class DeleteCurrentUser {
+
+    @Test
+    void should_DelegateToServiceAndReturn204() {
+      var response = controller.deleteCurrentUser();
+
+      verify(userService).deleteCurrentUser();
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
     }
   }
 


### PR DESCRIPTION
## Why

`DELETE /v1/users/me` was a 501 stub. The cascade FK design (migrations 012 + 014) already ensures that deleting the `users` row atomically wipes all owned data — the implementation just needed wiring up.

## What changed

- **`UserRepository`**: added `deleteById(UUID)` (Spring Data JDBC derived delete).
- **`UserService`**: injected `OwnerIdProvider<UUID>`, added `deleteCurrentUser()` — resolves the caller's UUID, deletes the row, and evicts the full `localUserIds` cache so a stale `(issuer, subject) → uuid` mapping is never served after the account is gone. Re-login with the same JWT re-provisions a fresh account via the existing JIT upsert.
- **`MeController`**: injected `UserService`, replaced the stub with a real implementation returning `204 No Content`.
- **`MeControllerTest`**: replaced the `UnsupportedOperationException` stub test with a delegation + status assertion; added `UserService` mock.
- **`UserServiceTest`**: added `deleteCurrentUser` unit test.
- **`MeDeleteCurrentUserIntegrationTest`**: new — covers 204 response, full cascade wipe of categories/transactions/preferences, cross-user isolation, and 401 for unauthenticated requests.

## How to verify

```bash
./gradlew test integrationTest --tests "*.MeDeleteCurrentUserIntegrationTest"
```

Manual smoke test:
1. Authenticate and create a category + transaction.
2. `DELETE /v1/users/me` → expect `204`.
3. Re-authenticate with the same credentials → expect a fresh empty account (new user UUID).
4. Confirm the other test user's data is unaffected.