### PR TITLE
fix: decouple Liquibase migration 009 from OIDC issuer URI

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,6 +7,8 @@ spring:
   liquibase:
     change-log: classpath:db/changelog/db.changelog-master.yaml
     enabled: true
+    parameters:
+      oidc-issuer-uri: ${spring.security.oauth2.resourceserver.jwt.issuer-uri}
   security:
     oauth2:
       resourceserver:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,8 +7,6 @@ spring:
   liquibase:
     change-log: classpath:db/changelog/db.changelog-master.yaml
     enabled: true
-    parameters:
-      oidc-issuer-uri: ${spring.security.oauth2.resourceserver.jwt.issuer-uri}
   security:
     oauth2:
       resourceserver:

--- a/src/main/resources/db/changelog/migrations/009-oidc-subject.sql
+++ b/src/main/resources/db/changelog/migrations/009-oidc-subject.sql
@@ -1,6 +1,7 @@
 --liquibase formatted sql
 
 --changeset g.remniov@gmail.com:009-oidc-subject
+--validCheckSum: ANY
 ALTER TABLE users
     ADD COLUMN oidc_issuer VARCHAR(255) NOT NULL DEFAULT '${oidc-issuer-uri}';
 


### PR DESCRIPTION
## Why

Changeset `009-oidc-subject` used a Liquibase property substitution (`${oidc-issuer-uri}`) to backfill the `oidc_issuer` column when it was introduced. Liquibase computes checksums **after** property substitution, so the checksum stored in `DATABASECHANGELOG` baked in the issuer URL at the time the migration first ran. Changing `OIDC_ISSUER_URI` (e.g. switching OIDC providers) would cause a checksum mismatch on startup, preventing the app from booting.

## What changed

- **`009-oidc-subject.sql`** — added `--validCheckSum: ANY` to the changeset header. This is Liquibase's built-in directive for changesets whose content legitimately varies by environment; it instructs Liquibase to skip checksum validation for this entry rather than fail on mismatch.

## How to verify

- Start the app against a DB where migration 009 was previously applied with a specific OIDC issuer URL, then change `OIDC_ISSUER_URI` to a different value — Liquibase should pass without a checksum error.
- Run `./gradlew integrationTest` to confirm migrations apply cleanly from scratch.

## Notes

Changing the OIDC issuer URL is still a data-level event: existing users have the old issuer stored in `oidc_issuer` and will get new accounts on next login. That requires a separate data migration (`UPDATE users SET oidc_issuer = '<new>' WHERE oidc_issuer = '<old>'`) and is out of scope here.